### PR TITLE
Make a PR fail when the internal link is missing

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -1,4 +1,4 @@
-import {warn, danger} from "danger"
+import {fail, warn, danger} from "danger"
 
 export const prSize = async () => {  
     // Warn when there is a big PR
@@ -11,7 +11,7 @@ export const internalLink = async () => {
     // Warn when link to internal task is missing
     for (let bodyLine of danger.github.pr.body.toLowerCase().split(/\n/)) {
         if (bodyLine.includes("task/issue url:") && (!bodyLine.includes("app.asana.com"))) {
-            warn("Please, don't forget to add a link to the internal task");
+            fail("Please, don't forget to add a link to the internal task");
         }
     }
 }

--- a/tests/internalLink.allPRs.test.ts
+++ b/tests/internalLink.allPRs.test.ts
@@ -6,6 +6,7 @@ import { internalLink } from '../org/allPRs'
 
 beforeEach(() => {
     dm.warn = jest.fn().mockReturnValue(true);
+    dm.fail = jest.fn().mockReturnValue(true);
 
     dm.danger = {
         github: {
@@ -17,17 +18,17 @@ beforeEach(() => {
 })
 
 describe("Internal Asana link test", () => {
-    it("does not warn when the description contains a link to Asana", async () => {
+    it("does not fail when the description contains a link to Asana", async () => {
         await internalLink()
         
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("warns when the description doesn't contain a link to Asana", async () => {
+    it("fails when the description doesn't contain a link to Asana", async () => {
         dm.danger.github.pr.body = 'task/issue url:' 
 
         await internalLink();
         
-        expect(dm.warn).toHaveBeenCalledWith("Please, don't forget to add a link to the internal task")
+        expect(dm.fail).toHaveBeenCalledWith("Please, don't forget to add a link to the internal task")
     })
 })


### PR DESCRIPTION
Task URL: https://app.asana.com/0/1200194497630846/1203759597036494/f

Update the internal link rule to make the PR fail. 