### PR TITLE
Fix xcode project configuration regex and add a test case for submodule changes

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -29,7 +29,7 @@ export const xcodeprojConfiguration = async () => {
             // * a space and an equality sign
             // * arbitrary number of any characters (the value can be empty)
             // * a semicolon
-            if (addedLines?.find(value => /^\+\t+[A-Z_0-9]* =.*;$/i.test(value))) {
+            if (addedLines?.find(value => /^\+\t+[A-Z_0-9]* =.*;$/.test(value))) {
                 fail("No configuration is allowed inside Xcode project file - use xcconfig files instead.");
             }
         }

--- a/tests/xcodeprojConfiguration.allPRs.test.ts
+++ b/tests/xcodeprojConfiguration.allPRs.test.ts
@@ -65,6 +65,17 @@ describe("Xcode project file configuration checks", () => {
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
+    it("does not fail with submodule changes", async () => {
+        dm.addedLines = `
++								branch = "test-branch";
++								kind = branch;
+        `
+
+        await xcodeprojConfiguration()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
     it("fails with added configuration", async () => {
         dm.addedLines = `
 +				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;


### PR DESCRIPTION
Task URL: https://app.asana.com/0/1203301625297703/1203811919852926/f

Description:
Make the regex case-sensitive as it should be from the beginning.