### PR TITLE
Add checks against committing licensed fonts and adding new colorsets

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -44,9 +44,21 @@ export const licensedFonts = async () => {
     }
 }
 
+export const newColors = async () => {
+    // Fail if new colors are added to the app (DesignResourcesKit)
+    if (danger.github.thisPR.repo == "iOS") {
+        const createdFiles = danger.git.created_files; 
+        if (createdFiles.some(path => path.match(/Assets.xcassets\/.*\.colorset/))) {
+            fail("DesignResourcesKit: No new colors should be added to this app.")
+        }
+    }
+}
+
 // Default run
 export default async () => {
     await prSize()
     await internalLink()
     await xcodeprojConfiguration()
+    await licensedFonts()
+    await newColors()
 }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -36,6 +36,14 @@ export const xcodeprojConfiguration = async () => {
     }
 }
 
+export const licensedFonts = async () => {
+    // Fail if licensed fonts are committed
+    const modifiedFiles = danger.git.modified_files; 
+    if (modifiedFiles.some(path => path.match(/fonts\/licensed\/.*\.otf/))) {
+        fail("Licensed fonts shouldn't be commited to this repository.")
+    }
+}
+
 // Default run
 export default async () => {
     await prSize()

--- a/tests/licensedFonts.allPRs.test.ts
+++ b/tests/licensedFonts.allPRs.test.ts
@@ -1,0 +1,53 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { licensedFonts } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.fail = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            modified_files: [],
+            created_files: [],
+            deleted_files: [],
+        },
+    };
+})
+
+describe("Licensed fonts checks", () => {
+    it("does not fail with no changed files", async () => {
+        dm.danger.git.modified_files = []
+
+        await licensedFonts()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with changes to other files", async () => {
+        dm.danger.git.modified_files = ["appStoreExportOptions.plist", "Core/AppConfigurationURLProvider.swift"]
+
+        await licensedFonts()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with changes to licensed fonts", async () => {
+        dm.danger.git.modified_files = ["appStoreExportOptions.plist", "Core/AppConfigurationURLProvider.swift", "fonts/licensed/proximanova-bold.otf"]
+
+        await licensedFonts()
+
+        expect(dm.fail).toHaveBeenCalledWith("Licensed fonts shouldn't be commited to this repository.")
+    })
+
+    it("fails with changes only to licensed fonts", async () => {
+        dm.danger.git.modified_files = ["/fonts/licensed/proximanova-bold.otf"]
+
+        await licensedFonts()
+
+        expect(dm.fail).toHaveBeenCalledWith("Licensed fonts shouldn't be commited to this repository.")
+    })
+
+})

--- a/tests/newColors.allPRs.test.ts
+++ b/tests/newColors.allPRs.test.ts
@@ -1,0 +1,59 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { newColors } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.fail = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            modified_files: ["Core/AppConfigurationURLProvider.swift"],
+            created_files: [],
+            deleted_files: [],
+        },
+        github: {
+            thisPR: {
+                repo: "iOS"
+            }
+        },
+    };
+})
+
+describe("New colors checks", () => {
+    it("does not fail with no created files", async () => {
+        dm.danger.git.modified_files = []
+
+        await newColors()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with changes to colorset files", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppConfigurationURLProvider.swift"]
+
+        await newColors()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with new colorset file", async () => {
+        dm.danger.git.created_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppConfigurationURLProvider.swift"]
+
+        await newColors()
+
+        expect(dm.fail).toHaveBeenCalledWith("DesignResourcesKit: No new colors should be added to this app.")
+    })
+
+    it("does not fail in others repos than iOS", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.created_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json"]
+
+        await newColors()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+})


### PR DESCRIPTION
Task URL: https://app.asana.com/0/1203301625297703/1204371418739710/f
https://app.asana.com/0/1203301625297703/1204375351752844/f

This PR adds two new rules: 
- Fails when files in the licensed fonts folder are updated. 
- Fails when a new colorset asset is added to the iOS repository