### PR TITLE
Add alert for trackerblocker URLs being out of sync

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -96,7 +96,12 @@ async function trackerBlockingMismatch(repository: string, modifiedFiles: any) {
             updateEmbeddedRegex = 'performUpdate \'https://staticcdn.duckduckgo.com/trackerblocking/(.*)\' \".*';
             break;
         case "macos-browser":
-            return;
+            tdsUrlProviderFilePath = 'DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift';
+            updateEmbeddedFilePath = 'scripts/update_embedded.sh';
+
+            tdsUrlProviderRegex = 'case \.trackerDataSet: return URL.string: \"(.*)\".*';
+            updateEmbeddedRegex = 'TDS_URL=\"(.*)\"';
+            break;
         default:
             return;
     } 
@@ -117,7 +122,12 @@ async function privacyConfigMismatch (repository: string, modifiedFiles: any) {
     // Configure
     switch (repository) {
         case "iOS":
-            return;
+            appConfigUrlProviderFilePath = 'Core/AppURLs.swift';
+            updateEmbeddedFilePath = 'scripts/update_embedded.sh';
+
+            configUrlProviderRegex = 'static let privacyConfig = URL.*string:.*staticBase.*trackerblocking\/config\/(.*)\".*';
+            updateEmbeddedRegex = 'performUpdate \'https://staticcdn.duckduckgo.com/trackerblocking/config/(.*)\' \".*';
+            break;
         case "macos-browser":
             appConfigUrlProviderFilePath = 'DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift';
             updateEmbeddedFilePath = 'scripts/update_embedded.sh';
@@ -128,7 +138,7 @@ async function privacyConfigMismatch (repository: string, modifiedFiles: any) {
         default:
             return;
     } 
-
+    
     const res = await checkForMismatch(modifiedFiles, appConfigUrlProviderFilePath, configUrlProviderRegex, updateEmbeddedFilePath, updateEmbeddedRegex);
     if (res) {
         fail(`Privacy Config URL mismatch. Please check ${appConfigUrlProviderFilePath} and ${updateEmbeddedFilePath}`)

--- a/tests/privacyConfigUrl.allPRs.test.ts
+++ b/tests/privacyConfigUrl.allPRs.test.ts
@@ -26,8 +26,8 @@ beforeEach(() => {
 
     dm.danger.github.utils.fileContents.mockReturnValue(Promise.resolve(""));
 })
-
-describe("Tracker Blocking URL checks on iOS", () => {
+/*
+describe("Privacy Config URL checks on iOS", () => {
     it("does not fail with no changes to relevant files", async () => {
         dm.danger.git.modified_files = []
 
@@ -53,8 +53,23 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
     it("fails with mismathing changes (only AppURLs.swift changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
-        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v4/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await embeddedFilesURLMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+    })
+
+    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v4/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
         appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
@@ -63,46 +78,31 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
-    })
-
-    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
-        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
-        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
-
-        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
-        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v6/current/ios-tds.json\")!";
-        
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
-
-        await embeddedFilesURLMismatch()
-
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
     it("fails with mismathing changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
-        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v7/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
-        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v5/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
-        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
-        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v6/current/ios-tds.json\")!";
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v4/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
         dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
     it("does not fail with mathing changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
-        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
-        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v4/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
-        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
-        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v6/current/ios-tds.json\")!";
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v4/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
         dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
@@ -113,7 +113,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
     it("fails with not matching regex", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
-        var updateEmbeddedContent = "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        var updateEmbeddedContent = "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
@@ -123,12 +123,12 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-})
-/*
-describe("Tracker Blocking URL checks on macOS", () => {
+})*/
+
+describe("Privacy Config URL checks on macOS", () => {
     it("does not fail with no changes to relevant files", async () => {
         dm.danger.git.modified_files = []
         dm.danger.github.thisPR.repo = "macos-browser"
@@ -157,16 +157,16 @@ describe("Tracker Blocking URL checks on macOS", () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
         
         dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
     it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
@@ -182,7 +182,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
     it("fails with mismathing changes (both files changed)", async () => {
@@ -198,7 +198,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
     it("does not fail with mathing changes (both files changed)", async () => {
@@ -230,7 +230,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-})*/
+})

--- a/tests/privacyConfigUrl.allPRs.test.ts
+++ b/tests/privacyConfigUrl.allPRs.test.ts
@@ -56,7 +56,7 @@ describe("Privacy Config URL checks on iOS", () => {
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
-    it("fails with mismathing changes (only AppURLs.swift changed)", async () => {
+    it("fails with mismatching changes (only AppURLs.swift changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -75,7 +75,7 @@ describe("Privacy Config URL checks on iOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+    it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v4/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -94,7 +94,7 @@ describe("Privacy Config URL checks on iOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (both files changed)", async () => {
+    it("fails with mismatching changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v5/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -184,7 +184,7 @@ describe("Privacy Config URL checks on macOS", () => {
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
-    it("fails with mismathing changes (only AppConfigurationURLProvider.swift changed)", async () => {
+    it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
@@ -206,7 +206,7 @@ describe("Privacy Config URL checks on macOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+    it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
@@ -228,7 +228,7 @@ describe("Privacy Config URL checks on macOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (both files changed)", async () => {
+    it("fails with mismatching changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
@@ -250,7 +250,7 @@ describe("Privacy Config URL checks on macOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-    it("does not fail with mathing changes (both files changed)", async () => {
+    it("does not fail with matching changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";

--- a/tests/privacyConfigUrl.allPRs.test.ts
+++ b/tests/privacyConfigUrl.allPRs.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 
     dm.danger.github.utils.fileContents.mockReturnValue(Promise.resolve(""));
 })
-/*
+
 describe("Privacy Config URL checks on iOS", () => {
     it("does not fail with no changes to relevant files", async () => {
         dm.danger.git.modified_files = []
@@ -39,12 +39,17 @@ describe("Privacy Config URL checks on iOS", () => {
     it("does not fail with unrelevant changes to relevant files", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
-        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-configNEW.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
-        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!\r\n";
+        appUrlsContent += "static let bloomFilter = URL(string: \"\\(staticBase)/https/https-mobileNEW-v2-bloom.bin\")!"
 
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -59,7 +64,11 @@ describe("Privacy Config URL checks on iOS", () => {
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v4/ios-config.json\")!\r\n";
         appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -74,7 +83,11 @@ describe("Privacy Config URL checks on iOS", () => {
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
         appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -89,14 +102,18 @@ describe("Privacy Config URL checks on iOS", () => {
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v4/ios-config.json\")!\r\n";
         appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-    it("does not fail with mathing changes (both files changed)", async () => {
+    it("does not fail with matching changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v4/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -104,7 +121,11 @@ describe("Privacy Config URL checks on iOS", () => {
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v4/ios-config.json\")!\r\n";
         appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -113,20 +134,24 @@ describe("Privacy Config URL checks on iOS", () => {
 
     it("fails with not matching regex", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
-        var updateEmbeddedContent = "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
-        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
         var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
         appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
         expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-})*/
+})
 
 describe("Privacy Config URL checks on macOS", () => {
     it("does not fail with no changes to relevant files", async () => {
@@ -144,9 +169,15 @@ describe("Privacy Config URL checks on macOS", () => {
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positivesNEW.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
 
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -160,9 +191,15 @@ describe("Privacy Config URL checks on macOS", () => {
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -176,9 +213,15 @@ describe("Privacy Config URL checks on macOS", () => {
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -192,9 +235,15 @@ describe("Privacy Config URL checks on macOS", () => {
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -204,13 +253,19 @@ describe("Privacy Config URL checks on macOS", () => {
     it("does not fail with mathing changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -220,13 +275,19 @@ describe("Privacy Config URL checks on macOS", () => {
     it("fails with not matching regex", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!\r\n";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 

--- a/tests/trackerBlockingUrl.allPRs.test.ts
+++ b/tests/trackerBlockingUrl.allPRs.test.ts
@@ -51,7 +51,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
-    it("fails with mismathing changes (only AppURLs.swift changed)", async () => {
+    it("fails with mismatching changes (only AppURLs.swift changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -66,7 +66,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+    it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -81,7 +81,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (both files changed)", async () => {
+    it("fails with mismatching changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v7/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -96,7 +96,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
     })
 
-    it("does not fail with mathing changes (both files changed)", async () => {
+    it("does not fail with matching changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
@@ -159,7 +159,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
-    it("fails with mismathing changes (only AppConfigurationURLProvider.swift changed)", async () => {
+    it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
@@ -181,7 +181,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+    it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
@@ -203,7 +203,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-    it("fails with mismathing changes (both files changed)", async () => {
+    it("fails with mismatching changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
@@ -225,7 +225,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-    it("does not fail with mathing changes (both files changed)", async () => {
+    it("does not fail with matching changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";

--- a/tests/trackerBlockingUrl.allPRs.test.ts
+++ b/tests/trackerBlockingUrl.allPRs.test.ts
@@ -127,7 +127,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
     })
 
 })
-/*
+
 describe("Tracker Blocking URL checks on macOS", () => {
     it("does not fail with no changes to relevant files", async () => {
         dm.danger.git.modified_files = []
@@ -144,9 +144,15 @@ describe("Tracker Blocking URL checks on macOS", () => {
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positivesNEW.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
 
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -157,12 +163,18 @@ describe("Tracker Blocking URL checks on macOS", () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -172,13 +184,19 @@ describe("Tracker Blocking URL checks on macOS", () => {
     it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -188,13 +206,19 @@ describe("Tracker Blocking URL checks on macOS", () => {
     it("fails with mismathing changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -204,13 +228,19 @@ describe("Tracker Blocking URL checks on macOS", () => {
     it("does not fail with mathing changes (both files changed)", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
@@ -220,17 +250,23 @@ describe("Tracker Blocking URL checks on macOS", () => {
     it("fails with not matching regex", async () => {
         dm.danger.github.thisPR.repo = "macos-browser"
         dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
         var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
+        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
+        appUrlsContent += "case .trackerDataSet2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
         
-        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+        dm.danger.github.utils.fileContents
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent))
+            .mockReturnValueOnce(Promise.resolve(appUrlsContent))
+            .mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
 
         await embeddedFilesURLMismatch()
 
         expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
     })
 
-})*/
+})

--- a/tests/trackerBlockingUrl.allPRs.test.ts
+++ b/tests/trackerBlockingUrl.allPRs.test.ts
@@ -1,0 +1,236 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { trackerBlockingMismatch } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.fail = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            modified_files: ["Core/AppConfigurationURLProvider.swift"],
+            created_files: [],
+            deleted_files: [],
+        },
+        github: {
+            thisPR: {
+                repo: "iOS"
+            },
+            utils: {
+                fileContents: jest.fn(),
+            }
+        },
+    };
+
+    dm.danger.github.utils.fileContents.mockReturnValue(Promise.resolve(""));
+})
+
+describe("Tracker Blocking URL checks on iOS", () => {
+    it("does not fail with no changes to relevant files", async () => {
+        dm.danger.git.modified_files = []
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with unrelevant changes to relevant files", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-configNEW.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
+
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with mismathing changes (only AppURLs.swift changed)", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+    })
+
+    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v6/current/ios-tds.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+    })
+
+    it("fails with mismathing changes (both files changed)", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v7/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v6/current/ios-tds.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+    })
+
+    it("does not fail with mathing changes (both files changed)", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v6/current/ios-tds.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with not matching regex", async () => {
+        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        var updateEmbeddedContent = "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
+        updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
+
+        var appUrlsContent = "static let privacyConfig = URL(string: \"\\(staticBase)/trackerblocking/config/v3/ios-config.json\")!\r\n";
+        appUrlsContent+= "static let trackerDataSet = URL(string: \"\\(staticBase)/trackerblocking/v5/current/ios-tds.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+    })
+
+})
+
+describe("Tracker Blocking URL checks on macOS", () => {
+    it("does not fail with no changes to relevant files", async () => {
+        dm.danger.git.modified_files = []
+        dm.danger.github.thisPR.repo = "macos-browser"
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with unrelevant changes to relevant files", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+
+        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positivesNEW.json\")!\r\n";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!";
+
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with mismathing changes (only AppConfigurationURLProvider.swift changed)", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+
+        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+    })
+
+    it("fails with mismathing changes (only update_embedded.sh changed)", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+
+        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+    })
+
+    it("fails with mismathing changes (both files changed)", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+
+        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+    })
+
+    it("does not fail with mathing changes (both files changed)", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+
+        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
+        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with not matching regex", async () => {
+        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+
+        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
+        appUrlsContent += "case .privacyConfiguration2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!";
+        
+        dm.danger.github.utils.fileContents.mockReturnValueOnce(Promise.resolve(appUrlsContent)).mockReturnValueOnce(Promise.resolve(updateEmbeddedContent));
+
+        await trackerBlockingMismatch()
+
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+    })
+
+})


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200194497630846/1205584545360104/f
Tech Design URL:
CC:

Description:
Add an alert for when TrackerBlocker URLs are updated in a way that they go out of sync between code and script. 

How to test:

- Make sure tests pass. 

- Check iOS implementation running Danger against https://github.com/duckduckgo/iOS/pull/2074: `yarn danger pr https://github.com/duckduckgo/iOS/pull/2074 --dangerfile ./org/allPRs.ts`

- If you have a DDG approved personal token, test macOS implementation running Danger against https://github.com/duckduckgo/macos-browser/pull/1731: `export DANGER_GITHUB_API_TOKEN='<your token>' &&yarn danger pr https://github.com/duckduckgo/iOS/pull/2074 --dangerfile ./org/allPRs.ts`
 