### PR TITLE
Add check for Definition of Done

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -189,6 +189,13 @@ export const embeddedFilesURLMismatch = async() => {
     await privacyConfigMismatch(repo, modifiedFiles)
 }
 
+export const dodChecked = async () => {
+    // Warn when DOD checkbox is not checked
+    if (!danger.github.pr.body.toLowerCase().includes("* [x] does this pr satisfy our [definition of done]")) {
+        fail("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f).");
+    }
+}
+
 // Default run
 export default async () => {
     await prSize()
@@ -198,4 +205,5 @@ export default async () => {
     await licensedFonts()
     await newColors()
     await embeddedFilesURLMismatch()
-}
+   // await dodChecked()
+}   

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -192,7 +192,7 @@ export const embeddedFilesURLMismatch = async() => {
 export const dodChecked = async () => {
     // Warn when DOD checkbox is not checked
     if (!danger.github.pr.body.toLowerCase().includes("* [x] does this pr satisfy our [definition of done]")) {
-        fail("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f).");
+        fail("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) and the relevant checkbox is checked.");
     }
 }
 

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -205,5 +205,5 @@ export default async () => {
     await licensedFonts()
     await newColors()
     await embeddedFilesURLMismatch()
-   // await dodChecked()
+    await dodChecked()
 }   

--- a/tests/checkDod.allPRs.test.ts
+++ b/tests/checkDod.allPRs.test.ts
@@ -25,7 +25,7 @@ describe("Definition of Done checked", () => {
 
         await dodChecked()
         
-        expect(dm.fail).toHaveBeenCalledWith("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f).")
+        expect(dm.fail).toHaveBeenCalledWith("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) and the relevant checkbox is checked.")
     })
 
     it("does fail when Definition of Done checkbox is not checked", async () => {
@@ -36,7 +36,7 @@ describe("Definition of Done checked", () => {
 
         await dodChecked()
         
-        expect(dm.fail).toHaveBeenCalledWith("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f).")
+        expect(dm.fail).toHaveBeenCalledWith("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) and the relevant checkbox is checked.")
     })
 
     it("does not fail when Definition of Done checkbox is checked (Lower Case)", async () => {
@@ -47,7 +47,7 @@ describe("Definition of Done checked", () => {
 
         await dodChecked()
         
-        expect(dm.fail).not.toHaveBeenCalledWith()
+        expect(dm.fail).not.toHaveBeenCalled()
     })
 
     it("does not fail when Definition of Done checkbox is checked (Upper Case)", async () => {
@@ -58,6 +58,6 @@ describe("Definition of Done checked", () => {
 
         await dodChecked()
         
-        expect(dm.fail).not.toHaveBeenCalledWith()
+        expect(dm.fail).not.toHaveBeenCalled()
     })
 })

--- a/tests/checkDod.allPRs.test.ts
+++ b/tests/checkDod.allPRs.test.ts
@@ -1,0 +1,63 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { dodChecked } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.warn = jest.fn().mockReturnValue(true);
+    dm.fail = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        github: {
+            pr: {
+                body: "",
+            }
+        },
+    }
+})
+
+describe("Definition of Done checked", () => {
+    it("does fail when Definition of Done checkbox is not in the body", async () => {
+        var prBody = "**Steps to test this PR**:\n1.\n2.\n"
+        prBody += "**Orientation Testing**:\n* [ ] Portrait\n* [ ] Landscape"
+        dm.danger.github.pr.body = prBody
+
+        await dodChecked()
+        
+        expect(dm.fail).toHaveBeenCalledWith("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f).")
+    })
+
+    it("does fail when Definition of Done checkbox is not checked", async () => {
+        var prBody = "**Steps to test this PR**:\n1.\n2.\n"
+        prBody += "**Definition of Done (Internal Only)**:\n* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?\n"
+        prBody += "**Orientation Testing**:\n* [ ] Portrait\n* [ ] Landscape"
+        dm.danger.github.pr.body = prBody
+
+        await dodChecked()
+        
+        expect(dm.fail).toHaveBeenCalledWith("Please, make sure this PR satisfies our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f).")
+    })
+
+    it("does not fail when Definition of Done checkbox is checked (Lower Case)", async () => {
+        var prBody = "**Steps to test this PR**:\n1.\n2.\n"
+        prBody += "**Definition of Done (Internal Only)**:\n* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?\n"
+        prBody += "**Orientation Testing**:\n* [ ] Portrait\n* [ ] Landscape"
+        dm.danger.github.pr.body = prBody
+
+        await dodChecked()
+        
+        expect(dm.fail).not.toHaveBeenCalledWith()
+    })
+
+    it("does not fail when Definition of Done checkbox is checked (Upper Case)", async () => {
+        var prBody = "**Steps to test this PR**:\n1.\n2.\n"
+        prBody += "**Definition of Done (Internal Only)**:\n* [X] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?\n"
+        prBody += "**Orientation Testing**:\n* [ ] Portrait\n* [ ] Landscape"
+        dm.danger.github.pr.body = prBody
+
+        await dodChecked()
+        
+        expect(dm.fail).not.toHaveBeenCalledWith()
+    })
+})


### PR DESCRIPTION
Asana Task: https://app.asana.com/0/1204165176092271/1209189118557663/f

Adds a check to verify that the "Conform to Definition of Done" checkbox has been checked. 
Makes PR checks fail otherwise.

Test:
This [iOS](https://github.com/duckduckgo/iOS/pull/3852) and this [macOS](https://github.com/duckduckgo/macos-browser/pull/3765) PRs point to this branch, so you can see this check in action by checking and unchecking the DoD box.  

