### PR TITLE
Update Danger to support monorepo changes

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -148,7 +148,7 @@ async function trackerBlockingMismatch(modifiedFiles: any) {
     let tdsUrlProvideriOSRegex = 'static let trackerDataSet = URL.*string:.*staticBase.*trackerblocking\/(.*)\".*';
     let updateEmbeddediOSRegex = 'performUpdate \'https://staticcdn.duckduckgo.com/trackerblocking/(.*)\' \".*';
 
-    let tdsUrlProviderFilemacOSPath = 'macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift';
+    let tdsUrlProviderFilemacOSPath = 'macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift';
     let updateEmbeddedFilemacOSPath = 'macOS/scripts/update_embedded.sh';
     let tdsUrlProvidermacOSRegex = 'public static let defaultTrackerDataURL = URL.string: \"(.*)\".*';
     let updateEmbeddedmacOSRegex = 'TDS_URL=\"(.*)\"';
@@ -171,7 +171,7 @@ async function privacyConfigMismatch(modifiedFiles: any) {
     let configUrlProvideriOSRegex = 'static let privacyConfig = URL.*string:.*staticBase.*trackerblocking\/config\/(.*)\".*';
     let updateEmbeddediOSRegex = 'performUpdate \'https://staticcdn.duckduckgo.com/trackerblocking/config/(.*)\' \".*';
 
-    let appConfigUrlProviderFilemacOSPath = 'macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift';
+    let appConfigUrlProviderFilemacOSPath = 'macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift';
     let updateEmbeddedFilemacOSPath = 'macOS/scripts/update_embedded.sh';
     let configUrlProvidermacOSRegex = 'public static let defaultPrivacyConfigurationURL = URL.string: \"(.*)\".*';
     let updateEmbeddedmacOSRegex = 'CONFIG_URL=\"(.*)\"';

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -118,7 +118,6 @@ export const newColors = async () => {
 
 async function extractUrl(filePath: string, regex: string, matchGroup: any): Promise<string> {
     const fileContents = await danger.github.utils.fileContents(filePath);
-
     var fileMatch = fileContents.match(regex);
     var extractedUrl = '';
     if (Array.isArray(fileMatch) && fileMatch.length > matchGroup) {
@@ -135,6 +134,7 @@ async function checkForMismatch(modifiedFiles: any, sourceCodeUrlFilePath: strin
     if (modifiedFiles.some(path => embeddedUrlFiles.includes(path))) {
         var sourceCodeFileContentsUrl = await extractUrl(sourceCodeUrlFilePath, sourceCodeUrlRegex, 1);
         var scriptContentsUrl = await extractUrl(scriptFilePath, scriptRegex, 1);
+
         return (sourceCodeFileContentsUrl != scriptContentsUrl);
     }
 

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -71,7 +71,7 @@ export const xcodeprojConfiguration_macOS = async () => {
             // * arbitrary number of any characters (the value can be empty)
             // * a semicolon
             if (addedLines?.find(value => /^\+\t+[A-Z_0-9]* =.*;$/.test(value))) {
-                fail("No configuration is allowed inside Xcode project file - use xcconfig files instead.");
+                fail("No configuration is allowed inside macOS Xcode project file - use xcconfig files instead.");
             }
         }
     }

--- a/tests/privacyConfigUrl.allPRs.test.ts
+++ b/tests/privacyConfigUrl.allPRs.test.ts
@@ -163,7 +163,7 @@ describe("Privacy Config URL checks on macOS", () => {
     })
 
     it("does not fail with unrelevant changes to relevant files", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -183,7 +183,7 @@ describe("Privacy Config URL checks on macOS", () => {
     })
 
     it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -199,7 +199,7 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
@@ -219,11 +219,11 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -239,11 +239,11 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\"";
 
@@ -263,7 +263,7 @@ describe("Privacy Config URL checks on macOS", () => {
     })
 
     it("fails with not matching regex", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -279,7 +279,7 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
 })

--- a/tests/privacyConfigUrl.allPRs.test.ts
+++ b/tests/privacyConfigUrl.allPRs.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
     dm.danger = {
         git: {
-            modified_files: ["Core/AppConfigurationURLProvider.swift"],
+            modified_files: ["iOS/Core/AppConfigurationURLProvider.swift"],
             created_files: [],
             deleted_files: [],
         },
@@ -37,7 +37,7 @@ describe("Privacy Config URL checks on iOS", () => {
     })
 
     it("does not fail with unrelevant changes to relevant files", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -57,7 +57,7 @@ describe("Privacy Config URL checks on iOS", () => {
     })
 
     it("fails with mismatching changes (only AppURLs.swift changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -72,11 +72,11 @@ describe("Privacy Config URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Privacy Config URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v4/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -91,11 +91,11 @@ describe("Privacy Config URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Privacy Config URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v5/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -110,11 +110,11 @@ describe("Privacy Config URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Privacy Config URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v4/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -133,7 +133,7 @@ describe("Privacy Config URL checks on iOS", () => {
     })
 
     it("fails with not matching regex", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -148,7 +148,7 @@ describe("Privacy Config URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Privacy Config URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
 })
@@ -156,22 +156,20 @@ describe("Privacy Config URL checks on iOS", () => {
 describe("Privacy Config URL checks on macOS", () => {
     it("does not fail with no changes to relevant files", async () => {
         dm.danger.git.modified_files = []
-        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.github.thisPR.repo = "apple-browsers"
         await embeddedFilesURLMismatch()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
     it("does not fail with unrelevant changes to relevant files", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positivesNEW.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/NEW\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
 
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -185,15 +183,13 @@ describe("Privacy Config URL checks on macOS", () => {
     })
 
     it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -203,19 +199,17 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -225,19 +219,17 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -247,19 +239,17 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -273,15 +263,13 @@ describe("Privacy Config URL checks on macOS", () => {
     })
 
     it("fails with not matching regex", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!\r\n";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL2 = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -291,7 +279,7 @@ describe("Privacy Config URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Privacy Config URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Privacy Config URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
 })

--- a/tests/trackerBlockingUrl.allPRs.test.ts
+++ b/tests/trackerBlockingUrl.allPRs.test.ts
@@ -10,13 +10,13 @@ beforeEach(() => {
 
     dm.danger = {
         git: {
-            modified_files: ["Core/AppConfigurationURLProvider.swift"],
+            modified_files: ["iOS/Core/AppConfigurationURLProvider.swift"],
             created_files: [],
             deleted_files: [],
         },
         github: {
             thisPR: {
-                repo: "iOS"
+                repo: "apple-browsers"
             },
             utils: {
                 fileContents: jest.fn(),
@@ -37,7 +37,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
     })
 
     it("does not fail with unrelevant changes to relevant files", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-configNEW.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -52,7 +52,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
     })
 
     it("fails with mismatching changes (only AppURLs.swift changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -63,11 +63,11 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -78,11 +78,11 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v7/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -93,11 +93,11 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -112,7 +112,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
     })
 
     it("fails with not matching regex", async () => {
-        dm.danger.git.modified_files = ["DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "scripts/update_embedded.sh", "Core/AppURLs.swift"]
+        dm.danger.git.modified_files = ["iOS/DuckDuckGo/Assets.xcassets/SomeColor.colorset/Contents.json", "iOS/scripts/update_embedded.sh", "iOS/Core/AppURLs.swift"]
         var updateEmbeddedContent = "performUpdate2 'https://staticcdn.duckduckgo.com/trackerblocking/v6/current/ios-tds.json' \"${base_dir}/Core/AppTrackerDataSetProvider.swift\" \"${base_dir}/Core/trackerData.json\\r\n";
         updateEmbeddedContent += "performUpdate 'https://staticcdn.duckduckgo.com/trackerblocking/config/v3/ios-config.json' \"${base_dir}/Core/AppPrivacyConfigurationDataProvider.swift\" \"${base_dir}/Core/ios-config.json\"";
 
@@ -123,7 +123,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check Core/AppURLs.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
 })
@@ -131,15 +131,14 @@ describe("Tracker Blocking URL checks on iOS", () => {
 describe("Tracker Blocking URL checks on macOS", () => {
     it("does not fail with no changes to relevant files", async () => {
         dm.danger.git.modified_files = []
-        dm.danger.github.thisPR.repo = "macos-browser"
+        dm.danger.github.thisPR.repo = "apple-browsers"
         await embeddedFilesURLMismatch()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
     it("does not fail with unrelevant changes to relevant files", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
@@ -160,8 +159,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
     })
 
     it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
@@ -178,12 +176,11 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
@@ -200,12 +197,11 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -222,12 +218,11 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
@@ -248,8 +243,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
     })
 
     it("fails with not matching regex", async () => {
-        dm.danger.github.thisPR.repo = "macos-browser"
-        dm.danger.git.modified_files = ["DuckDuckGo/AppDelegate/CopyHandler.swift", "scripts/update_embedded.sh", "DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
 
@@ -266,7 +260,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
 })

--- a/tests/trackerBlockingUrl.allPRs.test.ts
+++ b/tests/trackerBlockingUrl.allPRs.test.ts
@@ -63,7 +63,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
@@ -78,7 +78,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
@@ -93,7 +93,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
@@ -123,7 +123,7 @@ describe("Tracker Blocking URL checks on iOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("iOS Content Tracker URL mismatch. Please check iOS/Core/AppURLs.swift and iOS/scripts/update_embedded.sh")
     })
 
 })
@@ -139,13 +139,12 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
     it("does not fail with unrelevant changes to relevant files", async () => {
         dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positivesNEW.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/NEW\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
 
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -160,13 +159,12 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
     it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
         dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v7/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -176,18 +174,17 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
         dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v7/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -197,18 +194,17 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v4/current/macos-tds.json\"\r\n";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v5/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v7/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -218,18 +214,17 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
         dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v7/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v7/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -244,13 +239,12 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
     it("fails with not matching regex", async () => {
         dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
-        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
-        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\"";
+        var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
+        updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
-        var appUrlsContent = "case .bloomFilterExcludedDomains: return URL(string: \"https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json\")!\r\n";
-        appUrlsContent += "case .privacyConfiguration: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v3/macos-config.json\")!\r\n";
-        appUrlsContent += "case .surrogates: return URL(string: \"https://duckduckgo.com/contentblocking.js?l=surrogates\")!\r\n";
-        appUrlsContent += "case .trackerDataSet2: return URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\")!";
+        var appUrlsContent = "public static let baseTdsURLString = \"https://staticcdn.duckduckgo.com/trackerblocking/\"\r\n"
+        appUrlsContent += "public static let defaultTrackerDataURL2 = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\")!\r\n"
+        appUrlsContent += "public static let defaultPrivacyConfigurationURL = URL(string: \"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\")!"
         
         dm.danger.github.utils.fileContents
             .mockReturnValueOnce(Promise.resolve(appUrlsContent))
@@ -260,7 +254,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
 })

--- a/tests/trackerBlockingUrl.allPRs.test.ts
+++ b/tests/trackerBlockingUrl.allPRs.test.ts
@@ -138,7 +138,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
     })
 
     it("does not fail with unrelevant changes to relevant files", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -158,7 +158,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
     })
 
     it("fails with mismatching changes (only AppConfigurationURLProvider.swift changed)", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -174,7 +174,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (only update_embedded.sh changed)", async () => {
@@ -194,11 +194,11 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("fails with mismatching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v5/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -214,11 +214,11 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
     it("does not fail with matching changes (both files changed)", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v7/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -238,7 +238,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
     })
 
     it("fails with not matching regex", async () => {
-        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift"]
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/AppDelegate/CopyHandler.swift", "macOS/scripts/update_embedded.sh", "macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift"]
         var updateEmbeddedContent = "TDS_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/v6/current/macos-tds.json\"\r\n";
         updateEmbeddedContent += "CONFIG_URL=\"https://staticcdn.duckduckgo.com/trackerblocking/config/v4/macos-config.json\"";
 
@@ -254,7 +254,7 @@ describe("Tracker Blocking URL checks on macOS", () => {
 
         await embeddedFilesURLMismatch()
 
-        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/AppDelegate/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
+        expect(dm.fail).toHaveBeenCalledWith("macOS Content Tracker URL mismatch. Please check macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift and macOS/scripts/update_embedded.sh")
     })
 
 })

--- a/tests/xcodeprojConfiguration.allPRs.test.ts
+++ b/tests/xcodeprojConfiguration.allPRs.test.ts
@@ -83,7 +83,7 @@ describe("Xcode project file configuration checks", () => {
 
         await xcodeprojConfiguration_macOS()
         
-        expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside Xcode project file - use xcconfig files instead.")
+        expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside macOS Xcode project file - use xcconfig files instead.")
     })
 
     it("fails with added configuration with empty value", async () => {
@@ -93,7 +93,7 @@ describe("Xcode project file configuration checks", () => {
 
         await xcodeprojConfiguration_macOS()
         
-        expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside Xcode project file - use xcconfig files instead.")
+        expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside macOS Xcode project file - use xcconfig files instead.")
     })
 
     it("fails with added configuration with key containing digits", async () => {
@@ -103,7 +103,7 @@ describe("Xcode project file configuration checks", () => {
 
         await xcodeprojConfiguration_macOS()
         
-        expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside Xcode project file - use xcconfig files instead.")
+        expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside macOS Xcode project file - use xcconfig files instead.")
     })
 
     it("does not fail with added cofiguration in non-macos app repo", async () => {

--- a/tests/xcodeprojConfiguration.allPRs.test.ts
+++ b/tests/xcodeprojConfiguration.allPRs.test.ts
@@ -2,7 +2,7 @@ jest.mock("danger", () => jest.fn())
 import danger from 'danger'
 const dm = danger as any;
 
-import { xcodeprojConfiguration } from '../org/allPRs'
+import { xcodeprojConfiguration_macOS } from '../org/allPRs'
 
 beforeEach(() => {
     dm.addedLines = ""
@@ -14,7 +14,7 @@ beforeEach(() => {
                 return { added: dm.addedLines }
             },
             modified_files: [
-                "DuckDuckGo.xcodeproj/project.pbxproj"
+                "macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj"
             ]
         },
         github: {
@@ -23,7 +23,7 @@ beforeEach(() => {
                 deletions: 10
             },
             thisPR: {
-                repo: "macos-browser"
+                repo: "apple-browsers"
             }
         },
     }
@@ -33,7 +33,7 @@ describe("Xcode project file configuration checks", () => {
     it("does not fail with no changes to project file", async () => {
         dm.danger.git.modified_files = []
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
@@ -41,13 +41,13 @@ describe("Xcode project file configuration checks", () => {
     it("does not fail with no diff in project file", async () => {
         dm.danger.git.diffForFile = async (_filename) => {}
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
 
     it("does not fail with no additions", async () => {
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
@@ -60,7 +60,7 @@ describe("Xcode project file configuration checks", () => {
 +				372C27BE297AD5C200C758EB /* Test.swift in Sources */,
         `
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
@@ -71,7 +71,7 @@ describe("Xcode project file configuration checks", () => {
 +								kind = branch;
         `
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
@@ -81,7 +81,7 @@ describe("Xcode project file configuration checks", () => {
 +				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
         `
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
         
         expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside Xcode project file - use xcconfig files instead.")
     })
@@ -91,7 +91,7 @@ describe("Xcode project file configuration checks", () => {
 +				CODE_SIGN_IDENTITY = ;
         `
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
         
         expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside Xcode project file - use xcconfig files instead.")
     })
@@ -101,7 +101,7 @@ describe("Xcode project file configuration checks", () => {
 +				GCC_WARN_64_TO_32_BIT_CONVERSION = YES_ERROR;
         `
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
         
         expect(dm.fail).toHaveBeenCalledWith("No configuration is allowed inside Xcode project file - use xcconfig files instead.")
     })
@@ -112,10 +112,8 @@ describe("Xcode project file configuration checks", () => {
 +				GCC_WARN_64_TO_32_BIT_CONVERSION = YES_ERROR;
         `
 
-        await xcodeprojConfiguration()
+        await xcodeprojConfiguration_macOS()
 
         expect(dm.fail).not.toHaveBeenCalled()
     })
 })
-
-


### PR DESCRIPTION
Task: https://app.asana.com/0/1199333091098016/1209477587643660

This PR updates Danger to support the monorepo changes. It also fixes an issue where the macOS embedded file check was no longer working, as the format of that URL had changed.

To test this, see https://github.com/duckduckgo/apple-browsers/pull/82.