### PR TITLE
Add Danger check for @UserDefaultsWrapper additions

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -137,7 +137,7 @@ export const userDefaultsWrapper = async () => {
         if (foundOccurrence) {
             // trim leading + and whitespace
             const cleanLine = foundOccurrence.replace(/^\+\s*/, '').trim();
-            fail(`New \`@UserDefaultsWrapper\` definitions are not allowed. Please use \`KeyValueStoring\` protocol instead.\nFound this line:\n\`\`\`swift\n${cleanLine}\n\`\`\``);
+            fail(`New \`@UserDefaultsWrapper\` definitions are not allowed. Please use \`KeyedStoring\` protocol instead.\nFound this line:\n\`\`\`swift\n${cleanLine}\n\`\`\``);
             return;
         }
     }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -109,7 +109,7 @@ export const userDefaultsWrapper = async () => {
         if (foundOccurrence) {
             // trim leading + and whitespace
             const cleanLine = foundOccurrence.replace(/^\+\s*/, '').trim();
-            fail(`New \`@UserDefaultsWrapper\` definitions are not allowed. Please use \`KeyValueStoring\` protocl instead.\nFound this line:\n\`\`\`swift\n${cleanLine}\n\`\`\``);
+            fail(`New \`@UserDefaultsWrapper\` definitions are not allowed. Please use \`KeyValueStoring\` protocol instead.\nFound this line:\n\`\`\`swift\n${cleanLine}\n\`\`\``);
             return;
         }
     }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -149,10 +149,6 @@ export const remoteReleasableFeatureWarning = async () => {
         ...danger.git.created_files
     ].filter(file => file.endsWith(".swift"));
 
-    if (changedFiles.length === 0) {
-        return;
-    }
-
     for (const file of changedFiles) {
         let diff = await danger.git.diffForFile(file);
         let addedLines = diff?.added.split(/\n/);

--- a/tests/userDefaultsWrapper.allPRs.test.ts
+++ b/tests/userDefaultsWrapper.allPRs.test.ts
@@ -1,0 +1,127 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { userDefaultsWrapper } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.fail = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            diffForFile: async (_filename) => {
+                return { added: dm.addedLines }
+            },
+            modified_files: [
+                "ModifiedFile.swift"
+            ],
+            created_files: [
+                "CreatedFile.swift"
+            ]
+        }
+    }
+})
+
+describe("@UserDefaultsWrapper checks", () => {
+    it("does not fail with no changes to Swift files", async () => {
+        dm.danger.git.modified_files = []
+
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with no diff in Swift files", async () => {
+        dm.danger.git.diffForFile = async (_filename) => {}
+
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with no additions", async () => {
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with non-@UserDefaultsWrapper additions", async () => {
+        dm.addedLines = `
++		let subscription = PrivacyProSubscription(status: .inactive)
++       let isSubscribed: Bool
++       var billingPeriod: String?
++       public let startedAt: Int?
++       internal let expiresOrRenewsAt: Int?
++       private var paymentPlatform: String?
++       let status: String?
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with UserDefaultsWrapper usage additions", async () => {
+        dm.addedLines = `
++       let userDefaults: UserDefaults = UserDefaultsWrapper<Any>.sharedDefaults
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with commented out @UserDefaultsWrapper additions", async () => {
+        dm.addedLines = `
++		// @UserDefaultsWrapper(key: .homePageIsFavoriteVisible, defaultValue: true)
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with @UserDefaultsWrapper additions", async () => {
+        dm.addedLines = `
++		@UserDefaultsWrapper(key: .homePageIsFavoriteVisible, defaultValue: true)
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).toHaveBeenCalled()
+    })
+
+    it("fails with @UserDefaultsWrapper additions with open bracket only", async () => {
+        dm.addedLines = `
++		@UserDefaultsWrapper(
++           key: .homePageIsFavoriteVisible,
++           defaultValue: true
++       )
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).toHaveBeenCalled()
+    })
+
+    it("fails with @UserDefaultsWrapper additions without parameters", async () => {
+        dm.addedLines = `
++		@UserDefaultsWrapper
++       private var didCrashDuringCrashHandlersSetUp: Bool
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).toHaveBeenCalled()
+    })
+
+    it("does not fail with @UserDefaultsWrapper deletions", async () => {
+        dm.addedLines = `
+-		@UserDefaultsWrapper
+-       private var didCrashDuringCrashHandlersSetUp: Bool
+-
+-		@UserDefaultsWrapper(
+-           key: .homePageIsFavoriteVisible,
+-           defaultValue: true
+-       )
+-
+-		@UserDefaultsWrapper(key: .homePageIsFavoriteVisible, defaultValue: true)
+-       var isFavoriteVisible: Bool
+        `
+
+        await userDefaultsWrapper()
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Task URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210321655252710?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a CI check to prevent new `@UserDefaultsWrapper` definitions in Swift diffs.
> 
> - New `userDefaultsWrapper` rule scans added lines in `.swift` files and fails on `@UserDefaultsWrapper` annotations (handles parameterized, multiline, and no-parameter forms; ignores comments and non-definition usage)
> - Integrated the rule into the default Danger run in `allPRs.ts`
> - Added tests covering pass/fail scenarios for various annotation patterns
> - Minor cleanup: removed redundant early-return in `singletons()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7fdc709e24eb697b0ffbadb09c149bb3adabbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->