### PR TITLE
Add a check for macOS Xcode project objectVersion

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -1,6 +1,6 @@
 import {fail, warn, message, danger} from "danger"
 
-export const prSize = async () => {  
+export const prSize = async () => {
     // Define file types to exclude for iOS and macOS projects
     const excludedExtensions = ['.xcodeproj', '.xcassets', '.xcworkspace'];
 
@@ -11,7 +11,7 @@ export const prSize = async () => {
     ];
 
     // Filter out excluded file types
-    const filesToCheck = changedFiles.filter(file => 
+    const filesToCheck = changedFiles.filter(file =>
         !excludedExtensions.some(ext => file.includes(ext))
     );
 
@@ -77,6 +77,31 @@ export const xcodeprojConfiguration_macOS = async () => {
     }
 }
 
+export const xcodeprojObjectVersion_macOS = async () => {
+    const projectFile = "macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj";
+    if (danger.git.modified_files.includes(projectFile)) {
+        let diff = await danger.git.diffForFile(projectFile);
+        let addedLines = diff?.added.split(/\n/);
+        // The regex is equal to:
+        // * plus sign
+        // * 1 or more tabulation keys
+        // * `objectVersion` identifier (key)
+        // * a space, an equality sign and a space
+        // * a number
+        // * a semicolon
+        //
+        // We're capturing the number and if it's different than 60 (the required objectVersion), we fail the check.
+        const objectVersionMatch = addedLines?.find(value => {
+            const match = value.match(/^\+\t+objectVersion = ([0-9]+);$/);
+            console.log(value, match);
+            return match && parseInt(match[1]) > 60;
+        });
+        if (objectVersionMatch) {
+            fail("macOS Xcode project file needs to keep objectVersion at 60 - you may have added a buildable folder reference to the project file. Please replace it with a file group.");
+        }
+    }
+}
+
 export const singletons = async () => {
     const changedFiles = [
         ...danger.git.modified_files,
@@ -119,7 +144,7 @@ export const localizedStrings = async () => {
 
 export const licensedFonts = async () => {
     // Fail if licensed fonts are committed
-    const modifiedFiles = danger.git.modified_files; 
+    const modifiedFiles = danger.git.modified_files;
     if (modifiedFiles.some(path => path.match(/fonts\/licensed\/.*\.otf/))) {
         fail("Licensed fonts shouldn't be commited to this repository.")
     }
@@ -128,7 +153,7 @@ export const licensedFonts = async () => {
 export const newColors = async () => {
     // Fail if new colors are added to the app (DesignResourcesKit)
     if (danger.github.thisPR.repo == "apple-browsers") {
-        const createdFiles = danger.git.created_files; 
+        const createdFiles = danger.git.created_files;
         if (createdFiles.some(path => path.match(/iOS\/DuckDuckGo\/Assets.xcassets\/.*\.colorset/))) {
             fail("DesignResourcesKit: No new colors should be added to this app.")
         }
@@ -148,7 +173,7 @@ async function extractUrl(filePath: string, regex: string, matchGroup: any): Pro
 
 async function checkForMismatch(modifiedFiles: any, sourceCodeUrlFilePath: string, sourceCodeUrlRegex: string, scriptFilePath: string, scriptRegex: string) {
     const embeddedUrlFiles = [sourceCodeUrlFilePath, scriptFilePath];
-    
+
     // Run tests
     if (modifiedFiles.some(path => embeddedUrlFiles.includes(path))) {
         var sourceCodeFileContentsUrl = await extractUrl(sourceCodeUrlFilePath, sourceCodeUrlRegex, 1);
@@ -213,7 +238,7 @@ export const embeddedFilesURLMismatch = async() => {
     await privacyConfigMismatch(modifiedFiles)
 }
 
-export const releaseAndHotfixBranchBSKChangeWarning = async () => {  
+export const releaseAndHotfixBranchBSKChangeWarning = async () => {
     const branchName = danger.github.pr.head.ref;
     if (!branchName.startsWith('release/') && !branchName.startsWith('hotfix/')) return;
 
@@ -234,6 +259,7 @@ export default async () => {
     await prSize()
     await internalLink()
     await xcodeprojConfiguration_macOS()
+    await xcodeprojObjectVersion_macOS()
     await singletons()
     await localizedStrings()
     await licensedFonts()

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -90,7 +90,10 @@ export const xcodeprojObjectVersion_macOS = async () => {
         // * a number
         // * a semicolon
         //
-        // We're capturing the number and if it's different than 60 (the required objectVersion), we fail the check.
+        // We're capturing the number and if it's greater than 60 (the max supported objectVersion), we fail the check.
+        //
+        // NOTE: We should remove this check once we're able to use buildable folders in the macOS Xcode project file.
+        //
         const objectVersionMatch = addedLines?.find(value => {
             const match = value.match(/^\+\t+objectVersion = ([0-9]+);$/);
             console.log(value, match);

--- a/tests/xcodeprojObjectVersion.allPRs.test.ts
+++ b/tests/xcodeprojObjectVersion.allPRs.test.ts
@@ -1,0 +1,97 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { xcodeprojObjectVersion_macOS } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.fail = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            diffForFile: async (_filename) => {
+                return { added: dm.addedLines }
+            },
+            modified_files: [
+                "macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj"
+            ]
+        },
+        github: {
+            pr: {
+                additions: 200,
+                deletions: 10
+            },
+            thisPR: {
+                repo: "apple-browsers"
+            }
+        },
+    }
+})
+
+describe("Xcode project file configuration checks", () => {
+    it("does not fail with no changes to project file", async () => {
+        dm.danger.git.modified_files = []
+
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with no diff in project file", async () => {
+        dm.danger.git.diffForFile = async (_filename) => {}
+
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with no additions", async () => {
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with added source file", async () => {
+        dm.addedLines = `
++		372C27BE297AD5C200C758EB /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372C27BD297AD5C200C758EB /* Test.swift */; };
++		372C27BD297AD5C200C758EB /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
++				372C27BD297AD5C200C758EB /* Test.swift */,
++				372C27BE297AD5C200C758EB /* Test.swift in Sources */,
+        `
+
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with objectVersion change to 60", async () => {
+        dm.addedLines = `
++		objectVersion = 60;
+        `
+
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("does not fail with objectVersion change to a number lower than 60", async () => {
+        dm.addedLines = `
++		objectVersion = 55;
+        `
+
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).not.toHaveBeenCalled()
+    })
+
+    it("fails with objectVersion change to a number greater than 60", async () => {
+        dm.addedLines = `
++		objectVersion = 70;
+        `
+
+        await xcodeprojObjectVersion_macOS()
+
+        expect(dm.fail).toHaveBeenCalledWith("macOS Xcode project file needs to keep objectVersion at 60 - you may have added a buildable folder reference to the project file. Please replace it with a file group.")
+    })
+})


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211833448510890?focus=true

This change adds a check to ensure that macOS Xcode project’s objectVersion is at most 60.
It can’t be bumped higher because of incompatibility with old Xcode versions used on macOS 13 and macOS 14
UI Tests runners.

Steps to test:
* Verify that CI is green :)
* See https://github.com/duckduckgo/apple-browsers/pull/2408