### PR TITLE
Add a warning when adding a new parent feature flag

### DIFF
--- a/tests/remoteReleasableFeatureWarning.allPRs.test.ts
+++ b/tests/remoteReleasableFeatureWarning.allPRs.test.ts
@@ -1,0 +1,59 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { remoteReleasableFeatureWarning } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.warn = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            diffForFile: async (_filename) => {
+                return { added: dm.addedLines }
+            },
+            modified_files: [
+                "ModifiedFile.swift"
+            ],
+            created_files: [
+                "CreatedFile.swift"
+            ]
+        }
+    }
+})
+
+describe("remoteReleasable(.feature warning", () => {
+    it("does not warn with no changes to Swift files", async () => {
+        dm.danger.git.modified_files = ["ModifiedFile.m"]
+        dm.danger.git.created_files = []
+
+        await remoteReleasableFeatureWarning()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn with no diff in Swift files", async () => {
+        dm.danger.git.diffForFile = async (_filename) => {}
+
+        await remoteReleasableFeatureWarning()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn with deletions", async () => {
+        dm.addedLines = `
+-        .remoteReleasable(.feature("example"))
+        `
+
+        await remoteReleasableFeatureWarning()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns with remoteReleasable(.feature additions", async () => {
+        dm.addedLines = `
++        .remoteReleasable(.feature("example"))
+        `
+
+        await remoteReleasableFeatureWarning()
+        expect(dm.warn).toHaveBeenCalledWith("⚠️ Parent feature flags do not support rollouts - if you wish to use a rollout for your feature, please use a subfeature flag.")
+    })
+})


### PR DESCRIPTION
**Task:** https://app.asana.com/1/137249556945/project/1199333091098016/task/1212670452887355?focus=true

This PR adds a new check that warns when adding a new feature flag that uses a parent feature flag. The issue it warns about is that parent feature flags don't support rollouts, and if you want one then you should use a subfeature flag.

See https://github.com/duckduckgo/apple-browsers/pull/3064 for an example of this working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Danger check to flag additions of parent feature flags and wires it into PR validation, with unit tests.
> 
> - Introduces `remoteReleasableFeatureWarning` in `org/allPRs.ts` to scan Swift diffs for added lines containing `.remoteReleasable(.feature` and issue a `warn` with guidance
> - Integrates the new check into the default Danger run
> - Adds tests in `tests/remoteReleasableFeatureWarning.allPRs.test.ts` covering no Swift changes, no diff, deletions, and additions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff45fb711084aab11460f3b80e815cf0217b889d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->