### PR TITLE
Add check for proper feature flag task comment for all PR's

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -328,7 +328,10 @@ export const featureFlagAsanaLink = async () => {
                 continue;
             }
 
-            // Get the actual content (strip the leading +, -, or space)
+            // Skip removed lines – they don't exist in the new file
+            if (line.startsWith("-")) continue;
+
+            // Get the actual content (strip the leading + or space)
             const content = line.length > 0 ? line.substring(1) : "";
 
             // Track enum FeatureFlag declaration

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -288,6 +288,7 @@ export const releaseAndHotfixBranchBSKChangeWarning = async () => {
 }
 
 export const featureFlagAsanaLink = async () => {
+    warn(`Test`)
     const featureFlagFiles = [
         "iOS/Core/FeatureFlag.swift",
         "macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift"

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -287,6 +287,94 @@ export const releaseAndHotfixBranchBSKChangeWarning = async () => {
     warn(`Please check whether the BSK changes on this branch need to be merged to the other platform's release/hotfix branch`);
 }
 
+export const featureFlagAsanaLink = async () => {
+    const featureFlagFiles = [
+        "iOS/Core/FeatureFlag.swift",
+        "macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift"
+    ];
+
+    const changedFiles = [
+        ...danger.git.modified_files,
+        ...danger.git.created_files
+    ].filter(file => featureFlagFiles.includes(file));
+
+    if (changedFiles.length === 0) return;
+
+    const asanaTaskUrlRegex = /^\/\/\/\s*https:\/\/app\.asana\.com\/1\/137249556945\/project\/1211834678943996\/task\/\d+\s*$/;
+
+    for (const file of changedFiles) {
+        const diff = await danger.git.diffForFile(file);
+        if (!diff?.diff) continue;
+
+        const diffLines = diff.diff.split(/\n/);
+        let insideFeatureFlagEnum = false;
+        let braceDepth = 0;
+
+        for (let i = 0; i < diffLines.length; i++) {
+            const line = diffLines[i];
+
+            // Skip diff metadata lines
+            if (line.startsWith("---") || line.startsWith("+++") || line.startsWith("\\")) continue;
+
+            // Reset context on new hunk headers
+            if (line.startsWith("@@")) {
+                insideFeatureFlagEnum = false;
+                braceDepth = 0;
+                // Check if the hunk header context mentions FeatureFlag enum
+                if (/enum\s+FeatureFlag\b/.test(line)) {
+                    insideFeatureFlagEnum = true;
+                    braceDepth = 1;
+                }
+                continue;
+            }
+
+            // Get the actual content (strip the leading +, -, or space)
+            const content = line.length > 0 ? line.substring(1) : "";
+
+            // Track enum FeatureFlag declaration
+            if (/\benum\s+FeatureFlag\b/.test(content)) {
+                insideFeatureFlagEnum = true;
+                braceDepth = 0;
+            }
+
+            // Track brace depth when inside FeatureFlag enum
+            if (insideFeatureFlagEnum) {
+                braceDepth += (content.match(/{/g) || []).length;
+                braceDepth -= (content.match(/}/g) || []).length;
+
+                if (braceDepth <= 0) {
+                    insideFeatureFlagEnum = false;
+                    continue;
+                }
+            }
+
+            if (!insideFeatureFlagEnum) continue;
+
+            // Only check added lines for new case declarations
+            if (!line.startsWith("+")) continue;
+            if (!/^\s*case\s+\w+/.test(content)) continue;
+
+            // Found an added case line – walk upward through added comment lines looking for the Asana URL
+            let foundAsanaLink = false;
+            for (let j = i - 1; j >= 0; j--) {
+                const prevLine = diffLines[j];
+                if (!prevLine.startsWith("+")) break;
+                const prevContent = prevLine.substring(1).trim();
+                if (!prevContent.startsWith("///")) break;
+                if (asanaTaskUrlRegex.test(prevContent)) {
+                    foundAsanaLink = true;
+                    break;
+                }
+            }
+
+            if (!foundAsanaLink) {
+                warn(`New FeatureFlag case in \`${file}\` is missing a valid Feature Flag link in the comment.\nAdd a task in https://app.asana.com/1/137249556945/project/1211834678943996/list/1211838475578067 and use it in the comment.`);
+                return;
+            }
+        }
+    }
+}
+
 // Default run
 export default async () => {
     await prSize()
@@ -301,4 +389,5 @@ export default async () => {
     await newColors()
     await embeddedFilesURLMismatch()
     await releaseAndHotfixBranchBSKChangeWarning()
+    await featureFlagAsanaLink()
 }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -300,7 +300,7 @@ export const featureFlagAsanaLink = async () => {
 
     if (changedFiles.length === 0) return;
 
-    const asanaTaskUrlRegex = /^\/\/\/\s*https:\/\/app\.asana\.com\/1\/137249556945\/project\/1211834678943996\/task\/\d+\s*$/;
+    const asanaTaskUrlRegex = /^\/\/\/\s*https:\/\/app\.asana\.com\/1\/137249556945\/project\/1211834678943996\/task\/\d+(\?\S*)?\s*$/;
 
     for (const file of changedFiles) {
         const structuredDiff = await danger.git.structuredDiffForFile(file);

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -373,7 +373,7 @@ export const featureFlagAsanaLink = async () => {
 
     if (casesWithInvalidLinks.length > 0) {
         const caseList = casesWithInvalidLinks.map(c => `- \`${c.caseName}\` in \`${c.file}\``).join("\n");
-        warn(`New FeatureFlag cases are missing a valid Feature Flag link in the comment:\n${caseList}\nAdd a task in https://app.asana.com/1/137249556945/project/1211834678943996/list/1211838475578067 and use it in the comment.`);
+        warn(`New FeatureFlag cases are missing a valid Feature Flag link in the comment:\n${caseList}\n\nAdd a task in the [Feature Flags project](https://app.asana.com/1/137249556945/project/1211834678943996/list/1211838475578067) and use it in the comment.\nExpected format: \`/// https://app.asana.com/1/137249556945/project/1211834678943996/task/<task_id>\``);
     }
 }
 

--- a/tests/featureFlagAsanaLink.allPRs.test.ts
+++ b/tests/featureFlagAsanaLink.allPRs.test.ts
@@ -268,4 +268,19 @@ describe("Feature flag Asana link checks", () => {
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
+
+    it("reports all cases missing links in a single warning", async () => {
+        dm.rawDiff = `@@ -10,6 +10,10 @@ enum FeatureFlag {
++    case firstFeature
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case validFeature
++    case secondFeature`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const message = dm.warn.mock.calls[0][0]
+        expect(message).toContain("firstFeature")
+        expect(message).toContain("secondFeature")
+        expect(message).not.toContain("validFeature")
+    })
 })

--- a/tests/featureFlagAsanaLink.allPRs.test.ts
+++ b/tests/featureFlagAsanaLink.allPRs.test.ts
@@ -1,0 +1,233 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { featureFlagAsanaLink } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.diffContent = ""
+    dm.warn = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            diffForFile: async (_filename) => {
+                return { added: dm.diffContent, diff: dm.diffContent }
+            },
+            modified_files: [
+                "iOS/Core/FeatureFlag.swift"
+            ],
+            created_files: []
+        }
+    }
+})
+
+describe("Feature flag Asana link checks", () => {
+    it("does not fail when no feature flag files are changed", async () => {
+        dm.danger.git.modified_files = ["SomeOtherFile.swift"]
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not fail when diff has no added case lines", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    var rawValue: String
++    var source: FeatureFlagSource
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not fail when added case has valid Asana link above it", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not fail when added case with assignment has valid Asana link above it", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/999888777
++    case anotherFeature = "anotherFeature"
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("fails when added case has no comment above it", async () => {
+        dm.diffContent = `@@ -10,6 +10,7 @@ enum FeatureFlag {
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("fails when added case has a non-Asana comment above it", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    /// Some description of the feature
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("fails when added case has an Asana link with wrong project ID", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/9999999999999999/task/123456789
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("fails when comment above is a context line (not added)", async () => {
+        dm.diffContent = `@@ -10,6 +10,7 @@ enum FeatureFlag {
+ /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("works with macOS feature flag file", async () => {
+        dm.danger.git.modified_files = [
+            "macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift"
+        ]
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case macOSFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("fails for macOS feature flag file with missing link", async () => {
+        dm.danger.git.modified_files = [
+            "macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift"
+        ]
+        dm.diffContent = `@@ -10,6 +10,7 @@ enum FeatureFlag {
++    case macOSFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not fail when diff is empty", async () => {
+        dm.danger.git.diffForFile = async (_filename) => { return null }
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not fail for removed case lines", async () => {
+        dm.diffContent = `@@ -10,6 +10,5 @@ enum FeatureFlag {
+-    case removedFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not fail for case added in a different enum", async () => {
+        dm.diffContent = `@@ -50,6 +50,7 @@ enum SomeOtherEnum {
++    case otherEnumCase
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("fails for case in FeatureFlag enum but not in other enum in same diff", async () => {
+        dm.diffContent = `@@ -10,6 +10,7 @@ enum SomeOtherEnum {
++    case otherEnumCase
+@@ -50,6 +50,7 @@ enum FeatureFlag {
++    case featureFlagCase
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not fail for case in other enum when FeatureFlag cases are valid", async () => {
+        dm.diffContent = `@@ -10,6 +10,7 @@ enum SomeOtherEnum {
++    case otherEnumCase
+@@ -50,6 +50,8 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case featureFlagCase
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("tracks FeatureFlag enum declared in the diff itself", async () => {
+        dm.diffContent = `@@ -10,6 +10,10 @@
++enum FeatureFlag: String {
++    case myNewFeature
++}
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not fail when Asana link is above other comment lines", async () => {
+        dm.diffContent = `@@ -10,6 +10,10 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    /// Some description of the feature
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not fail when Asana link is several comment lines above case", async () => {
+        dm.diffContent = `@@ -10,6 +10,11 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    /// First line of description
++    /// Second line of description
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("fails when comment block has no Asana link at all", async () => {
+        dm.diffContent = `@@ -10,6 +10,10 @@ enum FeatureFlag {
++    /// First line of description
++    /// Second line of description
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not check cases after FeatureFlag enum closing brace", async () => {
+        dm.diffContent = `@@ -10,6 +10,12 @@
++enum FeatureFlag: String {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case validFeature
++}
++enum AnotherEnum {
++    case nolinkNeeded
++}
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+})

--- a/tests/featureFlagAsanaLink.allPRs.test.ts
+++ b/tests/featureFlagAsanaLink.allPRs.test.ts
@@ -75,6 +75,15 @@ describe("Feature flag Asana link checks", () => {
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
+    it("does not warn when Asana link has query parameters", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789?focus=true
++    case myNewFeature`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
     it("does not warn when added case with assignment has valid Asana link above it", async () => {
         dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/999888777

--- a/tests/featureFlagAsanaLink.allPRs.test.ts
+++ b/tests/featureFlagAsanaLink.allPRs.test.ts
@@ -230,4 +230,25 @@ describe("Feature flag Asana link checks", () => {
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
+
+    it("ignores braces from removed lines when tracking FeatureFlag enum scope", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+-    }
++    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns when removed braces would have hidden a missing link", async () => {
+        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+-    }
++    case myNewFeature
+`
+
+        await featureFlagAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
 })

--- a/tests/featureFlagAsanaLink.allPRs.test.ts
+++ b/tests/featureFlagAsanaLink.allPRs.test.ts
@@ -4,14 +4,42 @@ const dm = danger as any;
 
 import { featureFlagAsanaLink } from '../org/allPRs'
 
+// Helper to build a structuredDiff from a raw unified diff string.
+// Parses hunk headers (@@ lines) and change lines (+, -, context).
+function buildStructuredDiff(rawDiff: string) {
+    const lines = rawDiff.split(/\n/);
+    const chunks: any[] = [];
+    let currentChunk: any = null;
+
+    for (const line of lines) {
+        if (line.startsWith("@@")) {
+            currentChunk = { content: line, changes: [] };
+            chunks.push(currentChunk);
+        } else if (currentChunk && line.length > 0) {
+            let type: string;
+            if (line.startsWith("+")) {
+                type = "add";
+            } else if (line.startsWith("-")) {
+                type = "del";
+            } else {
+                type = "normal";
+            }
+            currentChunk.changes.push({ type, content: line });
+        }
+    }
+
+    return { chunks };
+}
+
 beforeEach(() => {
-    dm.diffContent = ""
+    dm.rawDiff = ""
     dm.warn = jest.fn().mockReturnValue(true);
 
     dm.danger = {
         git: {
-            diffForFile: async (_filename) => {
-                return { added: dm.diffContent, diff: dm.diffContent }
+            structuredDiffForFile: async (_filename) => {
+                if (!dm.rawDiff) return null;
+                return buildStructuredDiff(dm.rawDiff);
             },
             modified_files: [
                 "iOS/Core/FeatureFlag.swift"
@@ -22,77 +50,70 @@ beforeEach(() => {
 })
 
 describe("Feature flag Asana link checks", () => {
-    it("does not fail when no feature flag files are changed", async () => {
+    it("does not warn when no feature flag files are changed", async () => {
         dm.danger.git.modified_files = ["SomeOtherFile.swift"]
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("does not fail when diff has no added case lines", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+    it("does not warn when diff has no added case lines", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    var rawValue: String
-+    var source: FeatureFlagSource
-`
++    var source: FeatureFlagSource`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("does not fail when added case has valid Asana link above it", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+    it("does not warn when added case has valid Asana link above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("does not fail when added case with assignment has valid Asana link above it", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+    it("does not warn when added case with assignment has valid Asana link above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/999888777
-+    case anotherFeature = "anotherFeature"
-`
++    case anotherFeature = "anotherFeature"`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("fails when added case has no comment above it", async () => {
-        dm.diffContent = `@@ -10,6 +10,7 @@ enum FeatureFlag {
-+    case myNewFeature
-`
+    it("warns when added case has no comment above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum FeatureFlag {
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("fails when added case has a non-Asana comment above it", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+    it("warns when added case has a non-Asana comment above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    /// Some description of the feature
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("fails when added case has an Asana link with wrong project ID", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+    it("warns when added case has an Asana link with wrong project ID", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/9999999999999999/task/123456789
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("fails when comment above is a context line (not added)", async () => {
-        dm.diffContent = `@@ -10,6 +10,7 @@ enum FeatureFlag {
+    it("warns when comment above is a context line (not added)", async () => {
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum FeatureFlag {
  /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
@@ -102,151 +123,138 @@ describe("Feature flag Asana link checks", () => {
         dm.danger.git.modified_files = [
             "macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift"
         ]
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
-+    case macOSFeature
-`
++    case macOSFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("fails for macOS feature flag file with missing link", async () => {
+    it("warns for macOS feature flag file with missing link", async () => {
         dm.danger.git.modified_files = [
             "macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift"
         ]
-        dm.diffContent = `@@ -10,6 +10,7 @@ enum FeatureFlag {
-+    case macOSFeature
-`
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum FeatureFlag {
++    case macOSFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("does not fail when diff is empty", async () => {
-        dm.danger.git.diffForFile = async (_filename) => { return null }
+    it("does not warn when diff is empty", async () => {
+        dm.rawDiff = ""
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("does not fail for removed case lines", async () => {
-        dm.diffContent = `@@ -10,6 +10,5 @@ enum FeatureFlag {
--    case removedFeature
-`
+    it("does not warn for removed case lines", async () => {
+        dm.rawDiff = `@@ -10,6 +10,5 @@ enum FeatureFlag {
+-    case removedFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("does not fail for case added in a different enum", async () => {
-        dm.diffContent = `@@ -50,6 +50,7 @@ enum SomeOtherEnum {
-+    case otherEnumCase
-`
+    it("does not warn for case added in a different enum", async () => {
+        dm.rawDiff = `@@ -50,6 +50,7 @@ enum SomeOtherEnum {
++    case otherEnumCase`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("fails for case in FeatureFlag enum but not in other enum in same diff", async () => {
-        dm.diffContent = `@@ -10,6 +10,7 @@ enum SomeOtherEnum {
+    it("warns for case in FeatureFlag enum but not in other enum in same diff", async () => {
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum SomeOtherEnum {
 +    case otherEnumCase
 @@ -50,6 +50,7 @@ enum FeatureFlag {
-+    case featureFlagCase
-`
++    case featureFlagCase`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("does not fail for case in other enum when FeatureFlag cases are valid", async () => {
-        dm.diffContent = `@@ -10,6 +10,7 @@ enum SomeOtherEnum {
+    it("does not warn for case in other enum when FeatureFlag cases are valid", async () => {
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum SomeOtherEnum {
 +    case otherEnumCase
 @@ -50,6 +50,8 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
-+    case featureFlagCase
-`
++    case featureFlagCase`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
     it("tracks FeatureFlag enum declared in the diff itself", async () => {
-        dm.diffContent = `@@ -10,6 +10,10 @@
+        dm.rawDiff = `@@ -10,6 +10,10 @@
 +enum FeatureFlag: String {
 +    case myNewFeature
-+}
-`
++}`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("does not fail when Asana link is above other comment lines", async () => {
-        dm.diffContent = `@@ -10,6 +10,10 @@ enum FeatureFlag {
+    it("does not warn when Asana link is above other comment lines", async () => {
+        dm.rawDiff = `@@ -10,6 +10,10 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
 +    /// Some description of the feature
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("does not fail when Asana link is several comment lines above case", async () => {
-        dm.diffContent = `@@ -10,6 +10,11 @@ enum FeatureFlag {
+    it("does not warn when Asana link is several comment lines above case", async () => {
+        dm.rawDiff = `@@ -10,6 +10,11 @@ enum FeatureFlag {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
 +    /// First line of description
 +    /// Second line of description
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
-    it("fails when comment block has no Asana link at all", async () => {
-        dm.diffContent = `@@ -10,6 +10,10 @@ enum FeatureFlag {
+    it("warns when comment block has no Asana link at all", async () => {
+        dm.rawDiff = `@@ -10,6 +10,10 @@ enum FeatureFlag {
 +    /// First line of description
 +    /// Second line of description
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()
     })
 
     it("does not check cases after FeatureFlag enum closing brace", async () => {
-        dm.diffContent = `@@ -10,6 +10,12 @@
+        dm.rawDiff = `@@ -10,6 +10,12 @@
 +enum FeatureFlag: String {
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
 +    case validFeature
 +}
 +enum AnotherEnum {
 +    case nolinkNeeded
-+}
-`
++}`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
     it("ignores braces from removed lines when tracking FeatureFlag enum scope", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 -    }
 +    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/123456789
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
     it("warns when removed braces would have hidden a missing link", async () => {
-        dm.diffContent = `@@ -10,6 +10,8 @@ enum FeatureFlag {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum FeatureFlag {
 -    }
-+    case myNewFeature
-`
++    case myNewFeature`
 
         await featureFlagAsanaLink()
         expect(dm.warn).toHaveBeenCalled()


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212001845756281?focus=true

Adds a warning when there’s no valid asana task reference for modified FeatureFlag case. Checks both macOS and iOS.

Test PR in apple-browsers repo: https://github.com/duckduckgo/apple-browsers/pull/3632#issuecomment-3925682569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to CI/Danger warnings and new unit tests; no runtime app behavior changes, but diff-parsing heuristics could produce false positives/negatives.
> 
> **Overview**
> Adds a new Danger check (`featureFlagAsanaLink`) that scans diffs to `iOS/Core/FeatureFlag.swift` and `macOS/.../FeatureFlag.swift` and **warns when newly-added `case` entries in `enum FeatureFlag` lack a valid `/// https://app.asana.com/.../task/<id>` comment** (allowing optional query params) immediately above the added case.
> 
> Updates the default Danger run to execute this check, and adds a comprehensive Jest test suite covering valid/invalid links, iOS vs macOS paths, enum-scope detection, brace tracking, and multi-case reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ce13231f11a5ae6d18c563001862cf9de367c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->