### PR TITLE
Warn when pixel name starts with m_

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -377,6 +377,49 @@ export const featureFlagAsanaLink = async () => {
     }
 }
 
+export const pixelNamePrefix = async () => {
+    const changedFiles = [
+        ...danger.git.modified_files,
+        ...danger.git.created_files
+    ].filter(file => file.endsWith(".swift"));
+
+    // The regex matches lines like:
+    //   +    case appLaunch = "m_app_launch"
+    //   +    case foo(String) = "m_foo"
+    // It only triggers when the rawValue string literal starts with "m_".
+    // Breakdown:
+    // * `^\+`                       added line marker (not a deletion)
+    // * `(?!\s*\/\/)`               ignore commented-out lines
+    // * `\s*case\s+\w+`             a case declaration with an identifier
+    // * `(?:\([^)]*\))?`            optional associated value parentheses
+    // * `\s*=\s*"m_[^"]*"`          equals sign and a string literal starting with m_
+    const pixelCaseRegex = /^\+(?!\s*\/\/)\s*case\s+(\w+)(?:\([^)]*\))?\s*=\s*"(m_[^"]*)"/;
+
+    const offendingCases: { file: string; caseName: string; rawValue: string }[] = [];
+
+    for (const file of changedFiles) {
+        const diff = await danger.git.diffForFile(file);
+        const addedLines = diff?.added.split(/\n/);
+        if (!addedLines) continue;
+
+        for (const line of addedLines) {
+            const match = line.match(pixelCaseRegex);
+            if (match) {
+                offendingCases.push({ file, caseName: match[1], rawValue: match[2] });
+            }
+        }
+    }
+
+    if (offendingCases.length > 0) {
+        const caseList = offendingCases
+            .map(c => `- \`${c.caseName} = "${c.rawValue}"\` in \`${c.file}\``)
+            .join("\n");
+        warn(
+            `The \`m_\` pixel name prefix is no longer recommended. Please group pixels by app feature name instead.\n\nFound these new pixel cases:\n${caseList}\n\nNote: for iOS the platform suffix is added automatically by the pixel pipeline, so you do not need to include \`ios\` (or \`m_\`) in the pixel name. The same convention applies to macOS.`
+        );
+    }
+}
+
 // Default run
 export default async () => {
     await prSize()
@@ -392,4 +435,5 @@ export default async () => {
     await embeddedFilesURLMismatch()
     await releaseAndHotfixBranchBSKChangeWarning()
     await featureFlagAsanaLink()
+    await pixelNamePrefix()
 }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -383,19 +383,28 @@ export const pixelNamePrefix = async () => {
         ...danger.git.created_files
     ].filter(file => file.endsWith(".swift"));
 
-    // The regex matches lines like:
-    //   +    case appLaunch = "m_app_launch"
-    //   +    case foo(String) = "m_foo"
-    // It only triggers when the rawValue string literal starts with "m_".
-    // Breakdown:
-    // * `^\+`                       added line marker (not a deletion)
-    // * `(?!\s*\/\/)`               ignore commented-out lines
-    // * `\s*case\s+\w+`             a case declaration with an identifier
-    // * `(?:\([^)]*\))?`            optional associated value parentheses
-    // * `\s*=\s*"m_[^"]*"`          equals sign and a string literal starting with m_
-    const pixelCaseRegex = /^\+(?!\s*\/\/)\s*case\s+(\w+)(?:\([^)]*\))?\s*=\s*"(m_[^"]*)"/;
+    // The `m[_-]` prefix matches both the legacy underscore form (`m_foo_bar`)
+    // and the dashed form (`m-foo-bar`) that could appear if a pixel were
+    // ported to the new dash-separated naming convention while keeping the
+    // `m` namespace.
 
-    const offendingCases: { file: string; caseName: string; rawValue: string }[] = [];
+    // Matches an enum case with a rawValue string literal, e.g.:
+    //   +    case appLaunch = "m_app_launch"
+    //   +    case appLaunch = "m-app-launch"
+    //   +    case foo(String) = "m_foo"
+    const pixelCaseRegex = /^\+(?!\s*\/\/)\s*case\s+(\w+)(?:\([^)]*\))?\s*=\s*"(m[_-][^"]*)"/;
+
+    // Matches a PixelKit-style `var name: String` return, in both multi-line
+    // and inline-switch forms, e.g.:
+    //   +        return "m_app_launch"
+    //   +        return "m-app-launch"
+    //   +        case .foo: return "m_app_launch"
+    // The `.*` allows for arbitrary content (such as `case .x:`) between the
+    // line marker and the `return` keyword. The negative lookahead still rules
+    // out lines that begin with `//`.
+    const pixelReturnRegex = /^\+(?!\s*\/\/).*\breturn\s+"(m[_-][^"]*)"/;
+
+    const offendingCases: { file: string; snippet: string }[] = [];
 
     for (const file of changedFiles) {
         const diff = await danger.git.diffForFile(file);
@@ -403,19 +412,25 @@ export const pixelNamePrefix = async () => {
         if (!addedLines) continue;
 
         for (const line of addedLines) {
-            const match = line.match(pixelCaseRegex);
-            if (match) {
-                offendingCases.push({ file, caseName: match[1], rawValue: match[2] });
+            const caseMatch = line.match(pixelCaseRegex);
+            if (caseMatch) {
+                offendingCases.push({ file, snippet: `case ${caseMatch[1]} = "${caseMatch[2]}"` });
+                continue;
+            }
+
+            const returnMatch = line.match(pixelReturnRegex);
+            if (returnMatch) {
+                offendingCases.push({ file, snippet: `return "${returnMatch[1]}"` });
             }
         }
     }
 
     if (offendingCases.length > 0) {
         const caseList = offendingCases
-            .map(c => `- \`${c.caseName} = "${c.rawValue}"\` in \`${c.file}\``)
+            .map(c => `- \`${c.snippet}\` in \`${c.file}\``)
             .join("\n");
         warn(
-            `The \`m_\` pixel name prefix is no longer recommended. Please group pixels by app feature name instead.\n\nFound these new pixel cases:\n${caseList}\n\nNote: for iOS the platform suffix is added automatically by the pixel pipeline, so you do not need to include \`ios\` (or \`m_\`) in the pixel name. The same convention applies to macOS.`
+            `The \`m_\` (or \`m-\`) pixel name prefix is no longer recommended. Please group pixels by app feature name instead.\n\nFound these new pixel definitions:\n${caseList}\n\nNote: for iOS the platform suffix is added automatically by the pixel pipeline, so you do not need to include \`ios\` (or \`m_\`/\`m-\`) in the pixel name. The same convention applies to macOS.`
         );
     }
 }

--- a/tests/pixelNamePrefix.allPRs.test.ts
+++ b/tests/pixelNamePrefix.allPRs.test.ts
@@ -135,4 +135,131 @@ describe("pixel name prefix warning", () => {
         await pixelNamePrefix()
         expect(dm.warn).toHaveBeenCalledTimes(1)
     })
+
+    it("warns for PixelKit-style return with m_ prefix", async () => {
+        dm.addedLines = `
++        case .errorPageShown:
++            return "m_malicious-site-protection_error-page-shown"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("m_malicious-site-protection_error-page-shown")
+        expect(warnMessage).toContain("return")
+    })
+
+    it("does not warn for PixelKit return without m_ prefix", async () => {
+        dm.addedLines = `
++        case .errorPageShown:
++            return "malicious-site-protection_error-page-shown"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for commented-out return with m_ prefix", async () => {
+        dm.addedLines = `
++        // return "m_app_launch"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for removed return with m_ prefix", async () => {
+        dm.addedLines = `
+-            return "m_app_launch"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns for multiple PixelKit returns and lists each", async () => {
+        dm.addedLines = `
++        case .errorPageShown:
++            return "m_error_page_shown"
++        case .visitSite:
++            return "m_visit_site"
++        case .okayCase:
++            return "feature_okay"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("m_error_page_shown")
+        expect(warnMessage).toContain("m_visit_site")
+        expect(warnMessage).not.toContain("feature_okay")
+    })
+
+    it("warns for enum case rawValue with m- (dashed) prefix", async () => {
+        dm.addedLines = `
++        case appLaunch = "m-app-launch"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("m-app-launch")
+    })
+
+    it("warns for PixelKit return with m- (dashed) prefix", async () => {
+        dm.addedLines = `
++        case .dangerDashedOldPixel:
++            return "m-danger-pixelkit-dashed_warn"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("m-danger-pixelkit-dashed_warn")
+    })
+
+    it("does not warn for names starting with m followed by a letter (no separator)", async () => {
+        // Guards against false positives like `malicious-site-protection_*`,
+        // `mac_browser_*`, `match_foo`, etc. – these start with `m` but lack
+        // the `_` or `-` separator that defines the deprecated prefix.
+        dm.addedLines = `
++        case .errorPageShown:
++            return "malicious-site-protection_error-page-shown"
++        case .macBrowser:
++            return "mac_browser_open"
++        case .matchFoo = "match_foo"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns for inline switch case with m_ return (iOS PixelEvent style)", async () => {
+        dm.addedLines = `
++        case .dangerIssueOldPixel: return "m_danger_test_warn"
++        case .dangerNoIssue: return "danger_test_no_issue"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("m_danger_test_warn")
+        expect(warnMessage).not.toContain("danger_test_no_issue")
+    })
+
+    it("warns for mixed enum case and PixelKit return in one diff", async () => {
+        dm.addedLines = `
++        case appLaunch = "m_app_launch"
++        case .errorPageShown:
++            return "m_error_page_shown"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("case appLaunch")
+        expect(warnMessage).toContain("m_app_launch")
+        expect(warnMessage).toContain("m_error_page_shown")
+        expect(warnMessage).toContain("return")
+    })
 })

--- a/tests/pixelNamePrefix.allPRs.test.ts
+++ b/tests/pixelNamePrefix.allPRs.test.ts
@@ -1,0 +1,138 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { pixelNamePrefix } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.warn = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            diffForFile: async (_filename) => {
+                return { added: dm.addedLines }
+            },
+            modified_files: [
+                "ModifiedFile.swift"
+            ],
+            created_files: [
+                "CreatedFile.swift"
+            ]
+        }
+    }
+})
+
+describe("pixel name prefix warning", () => {
+    it("does not warn with no changes to Swift files", async () => {
+        dm.danger.git.modified_files = ["ModifiedFile.m"]
+        dm.danger.git.created_files = []
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn with no diff in Swift files", async () => {
+        dm.danger.git.diffForFile = async (_filename) => {}
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for case without m_ prefix", async () => {
+        dm.addedLines = `
++        case appLaunch = "feature_search_open"
++        case anotherEvent = "newtab_show"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when m_ appears outside of a rawValue string", async () => {
+        dm.addedLines = `
++        // legacy notes about m_ prefix history
++        let label = "this mentions m_something but is not a case"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for commented-out case with m_ prefix", async () => {
+        dm.addedLines = `
++        // case appLaunch = "m_app_launch"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for removed case with m_ prefix", async () => {
+        dm.addedLines = `
+-        case appLaunch = "m_app_launch"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns when an enum case rawValue starts with m_", async () => {
+        dm.addedLines = `
++        case appLaunch = "m_app_launch"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("appLaunch")
+        expect(warnMessage).toContain("m_app_launch")
+        expect(warnMessage).toContain("m_")
+    })
+
+    it("warns for case with associated value when rawValue starts with m_", async () => {
+        dm.addedLines = `
++        case openSomething(String) = "m_open_something"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+    })
+
+    it("lists multiple offending cases in a single warning", async () => {
+        dm.addedLines = `
++        case appLaunch = "m_app_launch"
++        case settingsOpen = "m_settings_open"
++        case okayCase = "feature_okay"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const warnMessage = dm.warn.mock.calls[0][0] as string
+        expect(warnMessage).toContain("appLaunch")
+        expect(warnMessage).toContain("settingsOpen")
+        expect(warnMessage).not.toContain("okayCase")
+    })
+
+    it("warns for cases added in macOS files", async () => {
+        dm.danger.git.modified_files = ["macOS/DuckDuckGo/Statistics/Pixel.swift"]
+        dm.danger.git.created_files = []
+        dm.addedLines = `
++        case macFeature = "m_mac_feature_open"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+    })
+
+    it("warns for cases added in iOS files", async () => {
+        dm.danger.git.modified_files = ["iOS/Core/PixelEvent.swift"]
+        dm.danger.git.created_files = []
+        dm.addedLines = `
++        case iosFeature = "m_ios_feature_open"
+        `
+
+        await pixelNamePrefix()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/1203301625297703/task/1215242245248000?focus=true

Warn when pixel name starts with m_

See https://app.asana.com/0/0/1215196143943983 for details


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI/Danger linting and tests; no runtime app behavior.
> 
> **Overview**
> Adds a **Danger** check on all PRs that flags **newly added** Swift pixel names using the deprecated **`m_` / `m-`** prefix, and wires it into the default `allPRs` pipeline alongside checks like `featureFlagAsanaLink`.
> 
> The **`pixelNamePrefix`** helper scans added lines in changed `.swift` files for enum raw values and PixelKit-style `return "..."` strings matching `m_` or `m-`, while skipping comments, deletions, and unrelated strings (e.g. names like `malicious-site-protection_*`). It emits one **`warn`** listing each offending snippet and file, and notes that pixels should be grouped by feature name and that platform suffixes are added by the pipeline.
> 
> Adds **`tests/pixelNamePrefix.allPRs.test.ts`** with broad coverage for iOS/macOS paths, dashed vs underscore prefixes, inline switch returns, and false-positive guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe129accd655cf696971fbc7570389db524b7886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->