### PR TITLE
Add Danger check for subscription funnel origin Asana links

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -377,6 +377,96 @@ export const featureFlagAsanaLink = async () => {
     }
 }
 
+export const subscriptionFunnelOriginAsanaLink = async () => {
+    const funnelOriginFiles = [
+        "iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift",
+        "macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift"
+    ];
+
+    const changedFiles = [
+        ...danger.git.modified_files,
+        ...danger.git.created_files
+    ].filter(file => funnelOriginFiles.includes(file));
+
+    if (changedFiles.length === 0) return;
+
+    const asanaTaskUrlRegex = /^\/\/\/\s*https:\/\/app\.asana\.com\/1\/137249556945\/project\/1207260194172075\/task\/1209784982258586(\?\S*)?\s*$/;
+    const casesWithInvalidLinks: { file: string; caseName: string }[] = [];
+
+    for (const file of changedFiles) {
+        const structuredDiff = await danger.git.structuredDiffForFile(file);
+        if (!structuredDiff) continue;
+
+        for (const chunk of structuredDiff.chunks) {
+            let insideFunnelOriginEnum = false;
+            let braceDepth = 0;
+
+            // Check if the hunk header context mentions the funnel origin enum
+            if (/enum\s+SubscriptionFunnelOrigin\b/.test(chunk.content)) {
+                insideFunnelOriginEnum = true;
+                braceDepth = 1;
+            }
+
+            const changes = chunk.changes;
+
+            for (let i = 0; i < changes.length; i++) {
+                const change = changes[i];
+
+                // Skip removed lines – they don't exist in the new file
+                if (change.type === "del") continue;
+
+                const content = change.content.length > 0 ? change.content.substring(1) : "";
+
+                // Track funnel origin enum declaration
+                if (/\benum\s+SubscriptionFunnelOrigin\b/.test(content)) {
+                    insideFunnelOriginEnum = true;
+                    braceDepth = 0;
+                }
+
+                // Track brace depth when inside the funnel origin enum
+                if (insideFunnelOriginEnum) {
+                    braceDepth += (content.match(/{/g) || []).length;
+                    braceDepth -= (content.match(/}/g) || []).length;
+
+                    if (braceDepth <= 0) {
+                        insideFunnelOriginEnum = false;
+                        continue;
+                    }
+                }
+
+                if (!insideFunnelOriginEnum) continue;
+
+                // Only check added lines for new case declarations
+                if (change.type !== "add") continue;
+                const caseMatch = content.match(/^\s*case\s+(\w+)/);
+                if (!caseMatch) continue;
+
+                // Found an added case line – walk upward through added comment lines looking for the Subscription Entry Points link
+                let foundAsanaLink = false;
+                for (let j = i - 1; j >= 0; j--) {
+                    const prevChange = changes[j];
+                    if (prevChange.type !== "add") break;
+                    const prevContent = prevChange.content.substring(1).trim();
+                    if (!prevContent.startsWith("///")) break;
+                    if (asanaTaskUrlRegex.test(prevContent)) {
+                        foundAsanaLink = true;
+                        break;
+                    }
+                }
+
+                if (!foundAsanaLink) {
+                    casesWithInvalidLinks.push({ file, caseName: caseMatch[1] });
+                }
+            }
+        }
+    }
+
+    if (casesWithInvalidLinks.length > 0) {
+        const caseList = casesWithInvalidLinks.map(c => `- \`${c.caseName}\` in \`${c.file}\``).join("\n");
+        warn(`New subscription funnel origin cases are missing a link to the Subscription Entry Points task:\n${caseList}\n\nUpdate the [Subscription Entry Points task](https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586) with the new origin(s) and reference it in the comment so the funnel-origin dashboards stay complete.\nExpected format: \`/// https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586\``);
+    }
+}
+
 export const pixelNamePrefix = async () => {
     const changedFiles = [
         ...danger.git.modified_files,
@@ -450,5 +540,6 @@ export default async () => {
     await embeddedFilesURLMismatch()
     await releaseAndHotfixBranchBSKChangeWarning()
     await featureFlagAsanaLink()
+    await subscriptionFunnelOriginAsanaLink()
     await pixelNamePrefix()
 }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -390,7 +390,7 @@ export const subscriptionFunnelOriginAsanaLink = async () => {
 
     if (changedFiles.length === 0) return;
 
-    const asanaTaskUrlRegex = /^\/\/\/\s*https:\/\/app\.asana\.com\/1\/137249556945\/project\/1207260194172075\/task\/1209784982258586(\?\S*)?\s*$/;
+    const asanaTaskUrlRegex = /^\/\/\/\s*https:\/\/app\.asana\.com\/1\/137249556945\/project\/1207260194172075\/task\/\d+(\?\S*)?\s*$/;
     const casesWithInvalidLinks: { file: string; caseName: string }[] = [];
 
     for (const file of changedFiles) {
@@ -463,7 +463,7 @@ export const subscriptionFunnelOriginAsanaLink = async () => {
 
     if (casesWithInvalidLinks.length > 0) {
         const caseList = casesWithInvalidLinks.map(c => `- \`${c.caseName}\` in \`${c.file}\``).join("\n");
-        warn(`New subscription funnel origin cases are missing a link to the Subscription Entry Points task:\n${caseList}\n\nUpdate the [Subscription Entry Points task](https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586) with the new origin(s) and reference it in the comment so the funnel-origin dashboards stay complete.\nExpected format: \`/// https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586\``);
+        warn(`New subscription funnel origin cases are missing a link to their Subscription Entry Points subtask:\n${caseList}\n\nAdd the new origin(s) under the [Subscription Entry Points task](https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586) and reference the matching subtask in the comment so the funnel-origin dashboards stay complete.\nExpected format: \`/// https://app.asana.com/1/137249556945/project/1207260194172075/task/<task_id>\``);
     }
 }
 

--- a/tests/subscriptionFunnelOriginAsanaLink.allPRs.test.ts
+++ b/tests/subscriptionFunnelOriginAsanaLink.allPRs.test.ts
@@ -32,6 +32,7 @@ function buildStructuredDiff(rawDiff: string) {
 }
 
 const SUBSCRIPTION_ENTRY_POINTS = "https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586";
+const SUBSCRIPTION_ENTRY_POINTS_SUBTASK = "https://app.asana.com/1/137249556945/project/1207260194172075/task/1209785835918102";
 
 beforeEach(() => {
     dm.rawDiff = ""
@@ -77,6 +78,15 @@ describe("Subscription funnel origin Asana link checks", () => {
         expect(dm.warn).not.toHaveBeenCalled()
     })
 
+    it("does not warn when added case links a specific entry-point subtask", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// ${SUBSCRIPTION_ENTRY_POINTS_SUBTASK}
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
     it("does not warn when Subscription Entry Points link has query parameters", async () => {
         dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
 +    /// ${SUBSCRIPTION_ENTRY_POINTS}?focus=true
@@ -113,9 +123,18 @@ describe("Subscription funnel origin Asana link checks", () => {
         expect(dm.warn).toHaveBeenCalled()
     })
 
-    it("warns when link points to a different task", async () => {
+    it("warns when link points to a task in a different project", async () => {
         dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
-+    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/9999999999999999
++    /// https://app.asana.com/1/137249556945/project/9999999999999999/task/1209785835918102
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns for a link missing the project segment", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// https://app.asana.com/1/137249556945/task/1209785835918102
 +    case myNewOrigin = "funnel_mynew_ios"`
 
         await subscriptionFunnelOriginAsanaLink()

--- a/tests/subscriptionFunnelOriginAsanaLink.allPRs.test.ts
+++ b/tests/subscriptionFunnelOriginAsanaLink.allPRs.test.ts
@@ -1,0 +1,247 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { subscriptionFunnelOriginAsanaLink } from '../org/allPRs'
+
+// Helper to build a structuredDiff from a raw unified diff string.
+// Parses hunk headers (@@ lines) and change lines (+, -, context).
+function buildStructuredDiff(rawDiff: string) {
+    const lines = rawDiff.split(/\n/);
+    const chunks: any[] = [];
+    let currentChunk: any = null;
+
+    for (const line of lines) {
+        if (line.startsWith("@@")) {
+            currentChunk = { content: line, changes: [] };
+            chunks.push(currentChunk);
+        } else if (currentChunk && line.length > 0) {
+            let type: string;
+            if (line.startsWith("+")) {
+                type = "add";
+            } else if (line.startsWith("-")) {
+                type = "del";
+            } else {
+                type = "normal";
+            }
+            currentChunk.changes.push({ type, content: line });
+        }
+    }
+
+    return { chunks };
+}
+
+const SUBSCRIPTION_ENTRY_POINTS = "https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586";
+
+beforeEach(() => {
+    dm.rawDiff = ""
+    dm.warn = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            structuredDiffForFile: async (_filename) => {
+                if (!dm.rawDiff) return null;
+                return buildStructuredDiff(dm.rawDiff);
+            },
+            modified_files: [
+                "iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift"
+            ],
+            created_files: []
+        }
+    }
+})
+
+describe("Subscription funnel origin Asana link checks", () => {
+    it("does not warn when no funnel origin files are changed", async () => {
+        dm.danger.git.modified_files = ["SomeOtherFile.swift"]
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when diff has no added case lines", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    // MARK: - Win-Back Offer Origins
++    // some comment`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when added case has the Subscription Entry Points link above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// ${SUBSCRIPTION_ENTRY_POINTS}
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when Subscription Entry Points link has query parameters", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// ${SUBSCRIPTION_ENTRY_POINTS}?focus=true
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when the Subscription Entry Points link is above other comment lines", async () => {
+        dm.rawDiff = `@@ -10,6 +10,11 @@ enum SubscriptionFunnelOrigin: String {
++    /// ${SUBSCRIPTION_ENTRY_POINTS}
++    /// User entered the funnel via some new surface.
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns when added case has no comment above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum SubscriptionFunnelOrigin: String {
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns when added case has a non-Subscription Entry Points comment above it", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// User entered the funnel via some new surface.
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns when link points to a different task", async () => {
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/9999999999999999
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns when the Subscription Entry Points link is a context line (not added)", async () => {
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum SubscriptionFunnelOrigin: String {
+ /// ${SUBSCRIPTION_ENTRY_POINTS}
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("works with the macOS funnel origin file", async () => {
+        dm.danger.git.modified_files = [
+            "macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift"
+        ]
+        dm.rawDiff = `@@ -10,6 +10,8 @@ enum SubscriptionFunnelOrigin: String {
++    /// ${SUBSCRIPTION_ENTRY_POINTS}
++    case macOSOrigin = "funnel_mynew_macos"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns for the macOS funnel origin file with missing link", async () => {
+        dm.danger.git.modified_files = [
+            "macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift"
+        ]
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum SubscriptionFunnelOrigin: String {
++    case macOSOrigin = "funnel_mynew_macos"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns for a newly created funnel origin file with a missing link", async () => {
+        dm.danger.git.modified_files = []
+        dm.danger.git.created_files = [
+            "iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift"
+        ]
+        dm.rawDiff = `@@ -10,6 +10,7 @@ enum SubscriptionFunnelOrigin: String {
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not warn for cases added to SubscriptionRestoreFunnelOrigin", async () => {
+        dm.rawDiff = `@@ -60,6 +60,7 @@ enum SubscriptionRestoreFunnelOrigin: String {
++    case myNewRestoreOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when diff is empty", async () => {
+        dm.rawDiff = ""
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for removed case lines", async () => {
+        dm.rawDiff = `@@ -10,6 +10,5 @@ enum SubscriptionFunnelOrigin: String {
+-    case removedOrigin = "funnel_removed_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for a case added in an unrelated enum", async () => {
+        dm.rawDiff = `@@ -50,6 +50,7 @@ enum SomeOtherEnum {
++    case otherEnumCase`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("tracks a funnel origin enum declared in the diff itself", async () => {
+        dm.rawDiff = `@@ -10,6 +10,10 @@
++enum SubscriptionFunnelOrigin: String {
++    case myNewOrigin = "funnel_mynew_ios"
++}`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("detects the enum from a context line when the hunk header omits it", async () => {
+        dm.rawDiff = `@@ -20,6 +20,7 @@ import Foundation
+ enum SubscriptionFunnelOrigin: String {
++    case myNewOrigin = "funnel_mynew_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not check cases after the funnel origin enum closing brace", async () => {
+        dm.rawDiff = `@@ -10,6 +10,12 @@
++enum SubscriptionFunnelOrigin: String {
++    /// ${SUBSCRIPTION_ENTRY_POINTS}
++    case validOrigin = "funnel_valid_ios"
++}
++enum AnotherEnum {
++    case noLinkNeeded
++}`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("reports all cases missing links in a single warning", async () => {
+        dm.rawDiff = `@@ -10,6 +10,10 @@ enum SubscriptionFunnelOrigin: String {
++    case firstOrigin = "funnel_first_ios"
++    /// ${SUBSCRIPTION_ENTRY_POINTS}
++    case validOrigin = "funnel_valid_ios"
++    case secondOrigin = "funnel_second_ios"`
+
+        await subscriptionFunnelOriginAsanaLink()
+        expect(dm.warn).toHaveBeenCalledTimes(1)
+        const message = dm.warn.mock.calls[0][0]
+        expect(message).toContain("firstOrigin")
+        expect(message).toContain("secondOrigin")
+        expect(message).not.toContain("validOrigin")
+    })
+})


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215777090564806?focus=true

### Description

Adds a new Danger check, `subscriptionFunnelOriginAsanaLink`, to `org/allPRs.ts` (registered in the default run). It mirrors the existing `featureFlagAsanaLink` check.

When a PR adds a new `case` to the `SubscriptionFunnelOrigin` enum in either:

- `iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift`
- `macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift`

…the check posts a soft, non-blocking `warn` unless a `/// https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586` comment linking the **Subscription Entry Points** task is present directly above the new case.

This guards against subscription funnel-origin instrumentation drift: as new entry points ship, the Subscription Entry Points task is kept up to date, so the funnel-origin dashboards stay complete. The periodic surges of `None` in those dashboards otherwise make them ineffective and undermine investigations into conversion-rate drops.

Scope is limited to the primary `SubscriptionFunnelOrigin` enum; `SubscriptionRestoreFunnelOrigin` and unrelated enums are ignored.

### Testing Steps

1. `yarn test` — full suite passes (170 tests), including the new `tests/subscriptionFunnelOriginAsanaLink.allPRs.test.ts` (20 tests).
2. Optionally, in an apple-browsers draft PR, add a `SubscriptionFunnelOrigin` case without the link comment and confirm Danger posts the warning; add the comment and confirm it clears.

### Impact and Risks

Low — CI tooling only. The check is a non-blocking `warn`; it cannot fail a build or block a merge.

#### What could go wrong?

- **Diff hunk-header reliance.** Detection of a case added to the existing enum depends on the enum name being present in the diff. Verified against the real file that git puts `enum SubscriptionFunnelOrigin` in the hunk header; the check also detects the enum from in-diff context lines as a fallback (covered by a test).
- **Hardcoded task ID.** The Subscription Entry Points task ID is hardcoded; if the task moves, the regex needs updating. This is intentional (single source of truth) and consistent with how `featureFlagAsanaLink` hardcodes its project ID.

### Quality Considerations

- Mirrors the established `featureFlagAsanaLink` pattern for consistency and low risk.
- 20 unit tests cover both platforms, link present/missing/wrong-task, context-vs-added lines, brace scope, created files, multi-case reporting, and the Restore-enum exclusion.

### Notes to Reviewer

- The logic is a near-verbatim copy of `featureFlagAsanaLink` — easiest to read as "same machinery, different file list / enum / URL / message." Extracting a shared helper across both checks is a possible follow-up, intentionally left out to keep this change focused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only soft warning with no merge blocking; behavior is covered by a dedicated test suite mirroring the existing feature-flag check.
> 
> **Overview**
> Adds a **non-blocking Danger check** `subscriptionFunnelOriginAsanaLink` and wires it into the default `allPRs` run, following the same structured-diff pattern as `featureFlagAsanaLink`.
> 
> When iOS or macOS `SubscriptionFunnelOrigin.swift` changes, new **`case` lines inside `SubscriptionFunnelOrigin`** must have an added `///` comment above them pointing at an Asana task in project `1207260194172075`. Otherwise Danger **`warn`s** with the case names and expected URL format. **`SubscriptionRestoreFunnelOrigin`** and other enums are out of scope.
> 
> New **`tests/subscriptionFunnelOriginAsanaLink.allPRs.test.ts`** covers valid/missing/wrong links, both platforms, created files, enum scoping, and batched warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508f31a306473d018c1b77bc8e8bced73a06666e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->