### PR TITLE
Add a Danger check to warn the developer of localised strings added t…

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -525,6 +525,26 @@ export const pixelNamePrefix = async () => {
     }
 }
 
+export const debugViewVerbatimText = async () => {
+    const changedFiles = [
+        ...danger.git.modified_files,
+        ...danger.git.created_files
+    ].filter(file => file.endsWith(".swift") && file.includes("Debug"));
+
+    for (const file of changedFiles) {
+        let diff = await danger.git.diffForFile(file);
+        let addedLines = diff?.added.split(/\n/);
+        // Matches added, non-commented lines containing Text("...") — use Text(verbatim:) in debug views to avoid translation.
+        const foundLine = addedLines?.find(value =>
+            /^\+(?!\s*\/\/).*\bText\s*\(\s*"/.test(value)
+        );
+        if (foundLine) {
+            const cleanLine = foundLine.replace(/^\+\s*/, '').trim();
+            warn(`Debug view \`${file}\` uses \`Text("...")\` which goes through the localization system. Use \`Text(verbatim:)\` instead to prevent strings from being translated:\n\`\`\`swift\n${cleanLine}\n\`\`\``);
+        }
+    }
+}
+
 // Default run
 export default async () => {
     await prSize()
@@ -542,4 +562,5 @@ export default async () => {
     await featureFlagAsanaLink()
     await subscriptionFunnelOriginAsanaLink()
     await pixelNamePrefix()
+    await debugViewVerbatimText()
 }

--- a/tests/debugViewVerbatimText.allPRs.test.ts
+++ b/tests/debugViewVerbatimText.allPRs.test.ts
@@ -1,0 +1,133 @@
+jest.mock("danger", () => jest.fn())
+import danger from 'danger'
+const dm = danger as any;
+
+import { debugViewVerbatimText as debugViewVerbatimText } from '../org/allPRs'
+
+beforeEach(() => {
+    dm.addedLines = ""
+    dm.warn = jest.fn().mockReturnValue(true);
+
+    dm.danger = {
+        git: {
+            diffForFile: async (_filename) => {
+                return { added: dm.addedLines }
+            },
+            modified_files: [
+                "Debug/DebugView.swift"
+            ],
+            created_files: []
+        }
+    }
+})
+
+describe("Debug view Text() checks", () => {
+    it("does not warn when no debug files are changed", async () => {
+        dm.danger.git.modified_files = ["SomeFeatureView.swift"]
+        dm.danger.git.created_files = []
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when no diff in debug files", async () => {
+        dm.danger.git.diffForFile = async (_filename) => {}
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn with no additions", async () => {
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn when Text(verbatim:) is used", async () => {
+        dm.addedLines = `
++           Text(verbatim: "Debug only label")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for commented-out Text(\"\")", async () => {
+        dm.addedLines = `
++           // Text("This is commented out")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for Text with a variable argument", async () => {
+        dm.addedLines = `
++           Text(someVariable)
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("warns when Text(\"...\") is added in a debug file", async () => {
+        dm.addedLines = `
++           Text("Debug label")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns when Text(\"...\") is added in a created debug file (Prefix)", async () => {
+        dm.danger.git.modified_files = []
+        dm.danger.git.created_files = ["Features/DebugMenuView.swift"]
+        dm.addedLines = `
++           Text("Some debug string")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns when Text(\"...\") is added in a created debug file (Middle)", async () => {
+        dm.danger.git.modified_files = []
+        dm.danger.git.created_files = ["Features/MenuDebugView.swift"]
+        dm.addedLines = `
++           Text("Some debug string")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("warns when Text(\"...\") is added in a created debug file (Folder)", async () => {
+        dm.danger.git.modified_files = []
+        dm.danger.git.created_files = ["Debug/MenuView.swift"]
+        dm.addedLines = `
++           Text("Some debug string")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does not warn for Text(\"...\") in non-debug Swift files", async () => {
+        dm.danger.git.modified_files = ["Features/HomeView.swift"]
+        dm.danger.git.created_files = []
+        dm.addedLines = `
++           Text("Hello world")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+
+    it("does not warn for removed Text(\"...\") lines in debug files", async () => {
+        dm.addedLines = `
+-           Text("Removed debug label")
+        `
+
+        await debugViewVerbatimText()
+        expect(dm.warn).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/137249556945/project/1203301625297703/task/1216060664481622

This PR adds a Danger check to prevent strings declared in Debug Menu views end up in Smartling


iOS Test PR to verify the warning https://github.com/duckduckgo/apple-browsers/pull/5567

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Danger rule and unit tests; no app runtime or localization pipeline changes.
> 
> **Overview**
> Adds a **Danger** check so PRs that introduce **`Text("...")`** in Swift files whose path contains **`Debug`** get a warning to use **`Text(verbatim:)`** instead, keeping debug-only copy out of the localization pipeline (e.g. Smartling).
> 
> The check scans **added** diff lines only, ignores comments and non–string-literal `Text` usage, and is registered in the default **`allPRs`** run. **Jest** coverage exercises debug vs non-debug paths, created vs modified files, and negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78feb8b57e229794678d9d7852d1613baafec727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->